### PR TITLE
Feat: Implement Multi-Stat Selection for Probability Calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,32 +365,27 @@
                     slot.map(statName => ({ ...statDetails[statName], slotIndex: index }))
                 );
 
-                const allSelectedGroups = selectionsBySlot.flat().map(s => s.group).filter(Boolean);
+                const allSelectedStatsFlat = selectionsBySlot.flat();
 
                 multiSelectContainers.forEach((container, containerIndex) => {
                     const list = container.querySelector('.multiselect-dropdown-list');
-                    const selectionsInThisSlot = selectionsBySlot[containerIndex];
-                    const groupsInThisSlot = selectionsInThisSlot.map(s => s.group).filter(Boolean);
 
                     list.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
                         const statName = checkbox.value;
                         const stat = statDetails[statName];
 
-                        checkbox.disabled = false; // Reset first
+                        // A stat is disabled if a stat with the same name or from the same group
+                        // is selected in a DIFFERENT slot.
+                        const isConflicting = allSelectedStatsFlat.some(selected => {
+                            // Don't check against the same slot
+                            if (selected.slotIndex === containerIndex) {
+                                return false;
+                            }
+                            // Check for conflict by group or name
+                            return (stat.group && stat.group === selected.group) || (stat.name === selected.name);
+                        });
 
-                        // Rule 1: A stat is selected in another slot.
-                        const conflictAcrossSlots = selectionsBySlot.flat().find(s =>
-                            s.slotIndex !== containerIndex && ((s.group && s.group === stat.group) || s.name === stat.name)
-                        );
-                        if (conflictAcrossSlots) {
-                            checkbox.disabled = true;
-                            return;
-                        }
-
-                        // Rule 2: A different group is already selected in THIS slot.
-                        if (groupsInThisSlot.length > 0 && stat.group && !groupsInThisSlot.includes(stat.group)) {
-                            checkbox.disabled = true;
-                        }
+                        checkbox.disabled = isConflicting;
                     });
                 });
             }


### PR DESCRIPTION
This commit introduces a major enhancement to the SpiritVale Stat Roll Calculator, allowing users to select multiple "good enough" stats for each equipment slot. It also incorporates several fixes based on user feedback to ensure correct and intuitive functionality.

Key changes include:

- **UI Overhaul:** Replaced `<select>` dropdowns with custom multi-select dropdowns with checkboxes.
- **Enhanced Calculation Engine:** Refactored the probability logic to compute four distinct scenarios: single/combined for both any/perfect rolls.
- **Redesigned Results Display:** Updated the results section to clearly present both "Single Combination" and "Combined" probabilities.
- **Corrected Stat Conflict Handling:** The logic for disabling conflicting stats has been fixed to correctly allow selection of stats from different groups within the same slot, while properly preventing group conflicts across different slots.
- **UX Fixes:**
    - The dropdown list now remains open when a user is clicking checkboxes, allowing for easier multi-selection.
    - Disabled (conflicting) stats are now styled with reduced opacity and a 'not-allowed' cursor to be more visually distinct.