### PR TITLE
Feat: Add navigation sidebar to all pages

### DIFF
--- a/damage_simulator.html
+++ b/damage_simulator.html
@@ -101,11 +101,22 @@
             align-items: center;
             margin-top: 0.5rem;
         }
+        #main-content {
+            margin-left: 12rem; /* 192px */
+        }
     </style>
 </head>
-<body class="p-4 md:p-8">
+<body class="p-4 md:p-8 bg-gray-900">
 
-    <div class="max-w-7xl mx-auto">
+    <div style="width: 12rem;" class="fixed left-0 top-0 h-full bg-gray-800 p-4">
+        <h2 class="text-lg font-semibold text-white mb-4">Tools</h2>
+        <ul>
+            <li class="mb-2"><a href="index.html" class="text-blue-400 hover:text-blue-300">Stat Calculator</a></li>
+            <li><a href="damage_simulator.html" class="text-blue-400 hover:text-blue-300 font-bold">Damage Simulator</a></li>
+        </ul>
+    </div>
+
+    <div id="main-content" class="max-w-7xl mx-auto">
         <header class="text-center mb-8">
             <h1 class="text-4xl font-bold text-white">Damage & Stat Simulator</h1>
             <p class="text-lg text-gray-400 mt-2">Enter your character and target stats to see the results.</p>

--- a/index.html
+++ b/index.html
@@ -23,11 +23,22 @@
         .calculator-panel {
              background-color: #1f2937; /* gray-800 */
         }
+        #main-content {
+            margin-left: 12rem; /* 192px */
+        }
     </style>
 </head>
-<body class="text-slate-300">
+<body class="text-slate-300 bg-gray-900">
 
-    <div class="min-h-screen flex flex-col items-center justify-center p-4">
+    <div style="width: 12rem;" class="fixed left-0 top-0 h-full bg-gray-800 p-4">
+        <h2 class="text-lg font-semibold text-white mb-4">Tools</h2>
+        <ul>
+            <li class="mb-2"><a href="index.html" class="text-blue-400 hover:text-blue-300 font-bold">Stat Calculator</a></li>
+            <li><a href="damage_simulator.html" class="text-blue-400 hover:text-blue-300">Damage Simulator</a></li>
+        </ul>
+    </div>
+
+    <div id="main-content" class="min-h-screen flex flex-col items-center justify-center p-4">
         <!-- Main Content -->
         <main class="w-full max-w-2xl mx-auto">
             <header class="text-center mb-8">


### PR DESCRIPTION
This commit introduces a navigation sidebar to both the Stat Roll Calculator and the Damage Simulator pages, allowing for easy navigation between the two tools.

Key changes include:

- A new, fixed-position sidebar has been added to both `index.html` and `damage_simulator.html`.
- The sidebar contains links to both the "Stat Calculator" and the "Damage Simulator".
- The main content of both pages has been given a left margin to accommodate the new sidebar, ensuring a clean and consistent layout.