### PR TITLE
Fix: Correct ATK formula in damage simulator

### DIFF
--- a/damage_simulator.html
+++ b/damage_simulator.html
@@ -451,9 +451,12 @@
             const t_flee = t_lv * 2, t_luk = t_lv * 0.5;
 
             // --- BASE CALCULATIONS ---
-            const mainStat = p_is_ranged ? p_stats.dex : p_stats.str;
             const total_bonus_atk = p_weapon_atk + p_atk;
             const total_bonus_matk = p_weapon_matk + p_matk;
+
+            const weaponSelect = document.getElementById('p_weapon_bad');
+            const selectedWeaponText = weaponSelect.options[weaponSelect.selectedIndex].text;
+            const mainStat = selectedWeaponText === "Bow" ? p_stats.dex : p_stats.str;
 
             const final_atk = (p_stats.lv / 4 + mainStat + Math.floor(p_stats.dex / 10) * 2 + p_mastery + total_bonus_atk * (1 + mainStat / 200)) *
                               (1 + p_atk_perc + Math.floor(mainStat / 10) / 100) * (p_twohanded ? 1.25 : 1);


### PR DESCRIPTION
This commit fixes a critical bug in the damage simulator where the `final_atk` calculation was not correctly using STR for melee weapons and DEX for bows.

The `calculateAll` function has been updated to determine the main stat (STR or DEX) based on the selected weapon type. If the selected weapon is a "Bow", DEX is used as the main stat; otherwise, STR is used. This ensures the ATK calculation is now correct for all weapon types.

The logic for identifying the weapon type has also been made more robust by checking the selected option's text instead of its value.