### PR TITLE
Remove balancing constant from Crit Rate formula

### DIFF
--- a/damage_simulator.html
+++ b/damage_simulator.html
@@ -743,7 +743,7 @@
 
             const aspd = 200 - 50 * p_bad * (1 - (p_stats.agi / 250 + p_stats.dex / 1000)) / (1 + p_aspd_perc) + 0.5 * Math.floor(p_stats.agi / 10);
             const attack_delay = Math.max(0.01, (200 - aspd) / 50);
-            const base_crit_rate = ((p_stats.luk / 3 + Math.floor(p_stats.luk / 10) + p_crit_flat) * (1 + p_crit_rate_perc)) - 5;
+            const base_crit_rate = ((p_stats.luk / 3 + Math.floor(p_stats.luk / 10) + p_crit_flat) * (1 + p_crit_rate_perc));
             const final_crit_rate = Math.max(0, base_crit_rate - base_crit_def) / 100;
             const crit_damage_multiplier = (120 + Math.floor(p_stats.luk / 10) + p_crit_dmg_perc) / 100;
             const final_hit = (p_stats.lv + p_stats.dex + 25);


### PR DESCRIPTION
This change removes the `- 5` constant from the `base_crit_rate` calculation in `damage_simulator.html` as requested by the user.