### PR TITLE
Refactor the Damage Simulator UI for elemental bonuses and add stat c…

### DIFF
--- a/damage_simulator.html
+++ b/damage_simulator.html
@@ -156,34 +156,53 @@
                         <div class="input-group"><label for="p_dmg_melee_perc">Damage Melee %</label><input id="p_dmg_melee_perc" type="number" value="0" class="recalculate"></div>
                         <div class="input-group"><label for="p_dmg_ranged_perc">Damage Ranged %</label><input id="p_dmg_ranged_perc" type="number" value="0" class="recalculate"></div>
                         <div class="input-group"><label for="p_dmg_magic_perc">Damage Magic %</label><input id="p_dmg_magic_perc" type="number" value="0" class="recalculate"></div>
-
-                        <h3 class="text-lg font-semibold col-span-2 mt-4 -mb-2 border-t border-gray-700 pt-4">Elemental Damage Bonus %</h3>
-                        <div class="input-group"><label for="p_dmg_bonus_neutral">Neutral</label><input id="p_dmg_bonus_neutral" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_bonus_poison">Poison</label><input id="p_dmg_bonus_poison" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_bonus_shadow">Shadow</label><input id="p_dmg_bonus_shadow" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_bonus_holy">Holy</label><input id="p_dmg_bonus_holy" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_bonus_fire">Fire</label><input id="p_dmg_bonus_fire" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_bonus_water">Water</label><input id="p_dmg_bonus_water" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_bonus_wind">Wind</label><input id="p_dmg_bonus_wind" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_bonus_earth">Earth</label><input id="p_dmg_bonus_earth" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_bonus_undead">Undead</label><input id="p_dmg_bonus_undead" type="number" value="0" class="recalculate"></div>
-
-                        <h3 class="text-lg font-semibold col-span-2 mt-4 -mb-2 border-t border-gray-700 pt-4">Damage versus Element %</h3>
-                        <div class="input-group"><label for="p_dmg_vs_neutral">vs Neutral</label><input id="p_dmg_vs_neutral" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_vs_poison">vs Poison</label><input id="p_dmg_vs_poison" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_vs_shadow">vs Shadow</label><input id="p_dmg_vs_shadow" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_vs_holy">vs Holy</label><input id="p_dmg_vs_holy" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_vs_fire">vs Fire</label><input id="p_dmg_vs_fire" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_vs_water">vs Water</label><input id="p_dmg_vs_water" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_vs_wind">vs Wind</label><input id="p_dmg_vs_wind" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_vs_earth">vs Earth</label><input id="p_dmg_vs_earth" type="number" value="0" class="recalculate"></div>
-                        <div class="input-group"><label for="p_dmg_vs_undead">vs Undead</label><input id="p_dmg_vs_undead" type="number" value="0" class="recalculate"></div>
-
                         <div class="input-group col-span-2"><label for="p_crit_flat">Flat CRIT</label><input id="p_crit_flat" type="number" value="5" class="recalculate"></div>
                         <div class="input-group"><label for="p_crit_rate_perc">Crit Rate %</label><input id="p_crit_rate_perc" type="number" value="10" class="recalculate"></div>
                         <div class="input-group"><label for="p_crit_dmg_perc">Crit Damage %</label><input id="p_crit_dmg_perc" type="number" value="20" class="recalculate"></div>
                         <div class="input-group"><label for="p_aspd_perc">AtkSpeed %</label><input id="p_aspd_perc" type="number" value="20" class="recalculate"></div>
                         <div class="input-group"><label for="p_cspd_perc">CastSpeed %</label><input id="p_cspd_perc" type="number" value="20" class="recalculate"></div>
+
+                        <div class="col-span-2 border-t border-gray-700 pt-4 -mb-2">
+                            <div class="checkbox-group">
+                                <label for="p_add_elemental_bonus">Elemental Damage Bonus %</label>
+                                <input id="p_add_elemental_bonus" type="checkbox" class="recalculate">
+                            </div>
+                        </div>
+                        <div id="elemental-bonus-inputs" class="hidden col-span-2 grid grid-cols-2 gap-4">
+                            <select id="p_dmg_bonus_element" class="recalculate">
+                                <option value="neutral">Neutral</option>
+                                <option value="poison">Poison</option>
+                                <option value="shadow">Shadow</option>
+                                <option value="holy">Holy</option>
+                                <option value="fire">Fire</option>
+                                <option value="water">Water</option>
+                                <option value="wind">Wind</option>
+                                <option value="earth">Earth</option>
+                                <option value="undead">Undead</option>
+                            </select>
+                            <input id="p_dmg_bonus_value" type="number" value="0" class="recalculate">
+                        </div>
+
+                        <div class="col-span-2 border-t border-gray-700 pt-4 -mb-2">
+                            <div class="checkbox-group">
+                                <label for="p_add_dmg_vs_element_bonus">Damage versus Element %</label>
+                                <input id="p_add_dmg_vs_element_bonus" type="checkbox" class="recalculate">
+                            </div>
+                        </div>
+                        <div id="dmg-vs-element-inputs" class="hidden col-span-2 grid grid-cols-2 gap-4">
+                            <select id="p_dmg_vs_element_element" class="recalculate">
+                                <option value="neutral">vs Neutral</option>
+                                <option value="poison">vs Poison</option>
+                                <option value="shadow">vs Shadow</option>
+                                <option value="holy">vs Holy</option>
+                                <option value="fire">vs Fire</option>
+                                <option value="water">vs Water</option>
+                                <option value="wind">vs Wind</option>
+                                <option value="earth">vs Earth</option>
+                                <option value="undead">vs Undead</option>
+                            </select>
+                            <input id="p_dmg_vs_element_value" type="number" value="0" class="recalculate">
+                        </div>
                     </div>
                 </div>
                  <div class="card">
@@ -536,7 +555,14 @@
             });
             document.getElementById('simulate_skills').addEventListener('change', toggleSkillSection);
             document.getElementById('p_dual_wield').addEventListener('change', toggleDualWield);
-
+            document.getElementById('p_add_elemental_bonus').addEventListener('change', () => {
+                document.getElementById('elemental-bonus-inputs').classList.toggle('hidden', !document.getElementById('p_add_elemental_bonus').checked);
+                calculateAll();
+            });
+            document.getElementById('p_add_dmg_vs_element_bonus').addEventListener('change', () => {
+                document.getElementById('dmg-vs-element-inputs').classList.toggle('hidden', !document.getElementById('p_add_dmg_vs_element_bonus').checked);
+                calculateAll();
+            });
 
             toggleSkillSection();
             toggleDualWield();
@@ -725,20 +751,17 @@
             const p_dmg_ranged_perc = getFloat('p_dmg_ranged_perc') / 100;
             const p_dmg_magic_perc = getFloat('p_dmg_magic_perc') / 100;
 
-            const p_dmg_bonus = {
-                neutral: getFloat('p_dmg_bonus_neutral') / 100, poison: getFloat('p_dmg_bonus_poison') / 100,
-                shadow: getFloat('p_dmg_bonus_shadow') / 100, holy: getFloat('p_dmg_bonus_holy') / 100,
-                fire: getFloat('p_dmg_bonus_fire') / 100, water: getFloat('p_dmg_bonus_water') / 100,
-                wind: getFloat('p_dmg_bonus_wind') / 100, earth: getFloat('p_dmg_bonus_earth') / 100,
-                undead: getFloat('p_dmg_bonus_undead') / 100
-            };
-            const p_dmg_vs = {
-                neutral: getFloat('p_dmg_vs_neutral') / 100, poison: getFloat('p_dmg_vs_poison') / 100,
-                shadow: getFloat('p_dmg_vs_shadow') / 100, holy: getFloat('p_dmg_vs_holy') / 100,
-                fire: getFloat('p_dmg_vs_fire') / 100, water: getFloat('p_dmg_vs_water') / 100,
-                wind: getFloat('p_dmg_vs_wind') / 100, earth: getFloat('p_dmg_vs_earth') / 100,
-                undead: getFloat('p_dmg_vs_undead') / 100
-            };
+            const p_dmg_bonus = { neutral: 0, poison: 0, shadow: 0, holy: 0, fire: 0, water: 0, wind: 0, earth: 0, undead: 0 };
+            if (getBool('p_add_elemental_bonus')) {
+                const element = getSelect('p_dmg_bonus_element');
+                p_dmg_bonus[element] = getFloat('p_dmg_bonus_value') / 100;
+            }
+
+            const p_dmg_vs = { neutral: 0, poison: 0, shadow: 0, holy: 0, fire: 0, water: 0, wind: 0, earth: 0, undead: 0 };
+            if (getBool('p_add_dmg_vs_element_bonus')) {
+                const element = getSelect('p_dmg_vs_element_element');
+                p_dmg_vs[element] = getFloat('p_dmg_vs_element_value') / 100;
+            }
 
             const p_crit_flat = getFloat('p_crit_flat');
             const p_crit_rate_perc = getFloat('p_crit_rate_perc') / 100;
@@ -783,19 +806,20 @@
             }
             // Final CTR % = [Base CTR %] + (100 - [Base CTR %]) * ([Cast Speed %] / 100)
             const final_ctr_perc = base_ctr_perc + (100 - base_ctr_perc) * p_cspd_perc;
-            const cast_time_reduction = Math.max(0, final_ctr_perc / 100);
+            const cast_time_reduction = Math.min(0.9, Math.max(0, final_ctr_perc / 100)); // Cap at 90%
             // Derive Cast Speed from the final Cast Time Reduction for display consistency
             const cast_speed = 200 - 50 * (1 - cast_time_reduction);
             // --- End New CTR Calculation ---
 
-            const aspd = 200 - 50 * p_bad * (1 - (p_stats.agi / 250 + p_stats.dex / 1000)) / (1 + p_aspd_perc) + 0.5 * Math.floor(p_stats.agi / 10);
+            let aspd = 200 - 50 * p_bad * (1 - (p_stats.agi / 250 + p_stats.dex / 1000)) / (1 + p_aspd_perc) + 0.5 * Math.floor(p_stats.agi / 10);
+            aspd = Math.min(aspd, 193); // Cap ASPD at 193
             const attack_delay = Math.max(0.01, (200 - aspd) / 50);
             const base_crit_rate = ((p_stats.luk / 3 + Math.floor(p_stats.luk / 10) + p_crit_flat) * (1 + p_crit_rate_perc));
             const final_crit_rate = Math.max(0, base_crit_rate - base_crit_def) / 100;
             const crit_damage_multiplier = (120 + Math.floor(p_stats.luk / 10) + p_crit_dmg_perc) / 100;
             const final_hit = (p_stats.lv + p_stats.dex + 25);
             const hit_chance = Math.min(100, 100 + final_hit - t_flee) / 100;
-            const final_block_chance = t_block_base; // Already calculated in updateTargetStatsFromArchetype
+            const final_block_chance = Math.min(75, t_block_base); // Cap at 75%
             const auto_attack_elemental_multiplier = getElementalMultiplier(p_element, t_element);
 
             // Per user spec, DamageReduction is 100 / (DEF + 100).


### PR DESCRIPTION
…aps.

- Replaced the long lists of inputs for "Elemental Damage Bonus %" and "Damage versus Element %" with a more user-friendly checkbox and dropdown system.
- Moved the "Flat CRIT", "Crit Rate %", "Crit Damage %", "AtkSpeed %", and "CastSpeed %" inputs to a more logical position within the "Equipment & Bonuses" card.
- Capped Attack Speed (ASPD) at 193.
- Capped Cast Time Reduction at 90%.
- Capped Block Chance at 75%.