### PR TITLE
feat: Use attack delay for zero-cooldown skills

### DIFF
--- a/damage_simulator.html
+++ b/damage_simulator.html
@@ -1174,7 +1174,18 @@
                     let totalHits = isMultiHit ? getFloat(`skill-${i}-base-hits`) + (getFloat(`skill-${i}-hits-per-level`) * level) : 1;
                     const isDot = getBool(`skill-${i}-is-dot`);
                     const finalCastTime = castTime * (1 - cast_time_reduction);
-                    totalCastTime += finalCastTime;
+
+                    if (castTime > 0) {
+                        // Skill has a cast time, add it to the rotation's cast sequence.
+                        totalCastTime += finalCastTime;
+                    } else if (cooldown === 0) {
+                        // Skill is instant and has no cooldown, so it's spammable.
+                        // Its contribution to rotation time is the base attack delay.
+                        totalCastTime += attack_delay;
+                    }
+                    // If castTime is 0 and cooldown > 0, the skill is an instant off-GCD.
+                    // It doesn't contribute to the sequence time, only to the longestCooldown.
+
                     longestCooldown = Math.max(longestCooldown, cooldown);
                     let percentScalingBonus = 0;
                     document.querySelectorAll(`#skill-${i}-scaling-container .scaling-rule`).forEach(rule => {


### PR DESCRIPTION
This commit updates the skill rotation calculation in the Damage Simulator.

If a skill has both a cast time and cooldown of 0, it should be treated as a spammable skill limited by the character's attack speed. The previous logic did not account for this, leading to a division-by-zero when calculating DPS.

The `calculateAll` function has been modified to use the `attack_delay` as the time cost for such skills. This ensures the rotation cycle time is always a positive value and that the DPS for these skills is calculated correctly.

The logic now correctly handles all scenarios:
- `castTime > 0`: Uses the final (reduced) cast time.
- `castTime = 0`, `cooldown = 0`: Uses the character's `attack_delay`.
- `castTime = 0`, `cooldown > 0`: Treats the skill as an instant off-GCD, contributing its cooldown to the rotation but not its cast time.