### PR TITLE
Refactor: Move changelog to footer and fix hover behavior

### DIFF
--- a/changelog.js
+++ b/changelog.js
@@ -96,11 +96,22 @@ document.addEventListener('DOMContentLoaded', () => {
     document.head.appendChild(style);
 
     // --- EVENT LISTENERS ---
-    changelogContainer.addEventListener('mouseenter', () => {
-        changelogPopup.classList.remove('hidden');
-    });
+    let hideTimeout;
 
-    changelogContainer.addEventListener('mouseleave', () => {
-        changelogPopup.classList.add('hidden');
-    });
+    const showPopup = () => {
+        clearTimeout(hideTimeout);
+        changelogPopup.classList.remove('hidden');
+    };
+
+    const startHideTimer = () => {
+        hideTimeout = setTimeout(() => {
+            changelogPopup.classList.add('hidden');
+        }, 100); // 100ms delay to allow moving mouse to popup
+    };
+
+    changelogContainer.addEventListener('mouseenter', showPopup);
+    changelogContainer.addEventListener('mouseleave', startHideTimer);
+
+    changelogPopup.addEventListener('mouseenter', showPopup);
+    changelogPopup.addEventListener('mouseleave', startHideTimer);
 });


### PR DESCRIPTION
This commit addresses two issues with the changelog component:

1.  The changelog button and its popup have been moved from the top of the sidebar to the bottom, where it now functions as a footer element. This was done to prevent the popup from rendering off-screen.

2.  The hover behavior of the changelog has been improved. Previously, the popup would disappear before the user could move their mouse over it to scroll. A delay has been added to the mouseleave event, and event listeners have been added to the popup itself. This ensures the popup remains visible when the user moves their mouse from the button to the popup, allowing for scrolling.