### PR TITLE
Fix: Correct JavaScript loading order in damage_simulator.html

### DIFF
--- a/damage_simulator.html
+++ b/damage_simulator.html
@@ -407,9 +407,9 @@
         </div>
     </div>
 
+    <script src="classes.js"></script>
     <script src="changelog.js" defer></script>
     <script src="sidebar.js"></script>
-    <script src="classes.js"></script>
     <script>
         // --- DATA ---
         const archetypeData = {


### PR DESCRIPTION
The inline script was executing before the external `classes.js` file, causing a ReferenceError because the `classes` variable was not defined. This broke all JavaScript functionality on the page.

This commit fixes the issue by moving the `<script src="classes.js"></script>` tag to load before the inline script that depends on it. This ensures the `classes` variable is available when the main application logic runs, restoring all page functionality.