### PR TITLE
Fix card droprate display in the database

### DIFF
--- a/database.html
+++ b/database.html
@@ -220,6 +220,14 @@
                 </div>`;
         }
 
+        function formatCardDroprate(droprate) {
+            if (!droprate) return '';
+            const rate = parseFloat(droprate.replace('%', ''));
+            if (isNaN(rate)) return droprate;
+            // Adjust for floating point inaccuracies and remove unnecessary trailing zeros
+            return Number((rate / 100).toFixed(2)) + '%';
+        }
+
         function renderCardsList(data) {
             const container = document.getElementById('cards-list');
             const itemsToRender = data || cardData;
@@ -242,7 +250,7 @@
                                 <p class="text-sm font-mono">${parseStats(card.Stats)}</p>
                             </div>
                              <div class="mt-auto pt-4 border-t border-gray-700/50 text-xs text-gray-400 space-y-1">
-                                <p>Source: <span class="monster-link font-semibold text-purple-400 cursor-pointer" data-monster-name="${card.Source}">${card.Source}</span> (${card.Droprate})</p>
+                                <p>Source: <span class="monster-link font-semibold text-purple-400 cursor-pointer" data-monster-name="${card.Source}">${card.Source}</span> (${formatCardDroprate(card.Droprate)})</p>
                                 <p>Location: ${card.Location}</p>
                             </div>
                         </div>


### PR DESCRIPTION
The droprate in the "Cards" section of the database was displayed incorrectly, showing values like "300%" instead of "3%".

This was caused by the raw droprate value from `Cards.json` being displayed directly without proper formatting.

This commit introduces a new JavaScript function, `formatCardDroprate`, which correctly formats the droprate by dividing it by 100. The `renderCardsList` function is updated to use this new function, ensuring the droprate is displayed correctly.