### PR TITLE
Refactor(CSS): Make item boxes responsive and condensed

### DIFF
--- a/database.html
+++ b/database.html
@@ -197,11 +197,11 @@
                     const container = document.getElementById('equipment-list');
                     const itemsToRender = data || equipmentData;
                     container.innerHTML = `
-                        <div class="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-6">
+                        <div class="grid grid-cols-[repeat(auto-fill,minmax(420px,1fr))] gap-4">
                             ${itemsToRender.map(item => `
-                                <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-5 flex flex-col transition-all hover:border-indigo-500/50 hover:shadow-2xl hover:shadow-indigo-500/10">
-                                    <div class="flex items-start mb-4">
-                                        <img src="https://placehold.co/64x64/1f2937/7c3aed?text=${item.Name.substring(0,1)}" alt="${item.Name}" class="w-16 h-16 rounded-md bg-gray-700 mr-4 flex-shrink-0">
+                                <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 flex flex-col transition-all hover:border-indigo-500/50 hover:shadow-2xl hover:shadow-indigo-500/10">
+                                    <div class="flex items-start mb-3">
+                                        <img src="https://placehold.co/64x64/1f2937/7c3aed?text=${item.Name.substring(0,1)}" alt="${item.Name}" class="w-12 h-12 rounded-md bg-gray-700 mr-4 flex-shrink-0">
                                         <div class="flex-1">
                                             <h3 class="font-bold text-lg text-white leading-tight">${item.Name}</h3>
                                             <div class="mt-1 flex items-center flex-wrap">
@@ -236,11 +236,11 @@
                     const container = document.getElementById('cards-list');
                     const itemsToRender = data || cardData;
                     container.innerHTML = `
-                        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6">
+                        <div class="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
                             ${itemsToRender.map(card => `
-                                <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-5 flex flex-col transition-all hover:border-purple-500/50 hover:shadow-2xl hover:shadow-purple-500/10">
-                                     <div class="flex items-start mb-4">
-                                        <img src="https://placehold.co/40x40/1f2937/a855f7?text=C" alt="Card" class="w-10 h-10 rounded-md bg-gray-700 mr-4 flex-shrink-0">
+                                <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 flex flex-col transition-all hover:border-purple-500/50 hover:shadow-2xl hover:shadow-purple-500/10">
+                                     <div class="flex items-start mb-3">
+                                        <img src="https://placehold.co/40x40/1f2937/a855f7?text=C" alt="Card" class="w-10 h-10 rounded-md bg-gray-700 mr-3 flex-shrink-0">
                                         <div class="flex-1">
                                             <p class="text-xs font-bold uppercase text-purple-400">${card.Affix}</p>
                                             <h3 class="font-bold text-lg text-white leading-tight">${card.Name}</h3>
@@ -266,11 +266,11 @@
                     const container = document.getElementById('artifacts-list');
                     const itemsToRender = data || artifactData;
                     container.innerHTML = `
-                        <div class="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-6">
+                        <div class="grid grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-4">
                             ${itemsToRender.map(artifact => `
-                                <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-5 transition-all hover:border-teal-500/50 hover:shadow-2xl hover:shadow-teal-500/10">
-                                    <h3 class="font-bold text-xl text-white mb-4">${artifact.SetName} Set</h3>
-                                    <div class="space-y-3">
+                                <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 transition-all hover:border-teal-500/50 hover:shadow-2xl hover:shadow-teal-500/10">
+                                    <h3 class="font-bold text-xl text-white mb-3">${artifact.SetName} Set</h3>
+                                    <div class="space-y-2">
                                         ${artifact.PerPieceBonus ? `<div><p class="text-xs text-gray-500 uppercase font-semibold">Per Piece Bonus</p><p class="text-sm font-mono">${parseStats(artifact.PerPieceBonus)}</p></div>` : ''}
                                         ${artifact.PerRefineBonus ? `<div><p class="text-xs text-gray-500 uppercase font-semibold">Per Refine Bonus</p><p class="text-sm font-mono">${parseStats(artifact.PerRefineBonus)}</p></div>` : ''}
                                         ${artifact.FullSetBonus ? `<div><p class="text-xs text-gray-500 uppercase font-semibold">Full Set Bonus</p><p class="text-sm font-mono">${parseStats(artifact.FullSetBonus)}</p></div>` : ''}


### PR DESCRIPTION
This commit refactors the layout of the item boxes on the database pages (Equipment, Cards, and Artifacts) to be more space-efficient and responsive.

- Replaced fixed-column grid layouts with a responsive grid using 'repeat(auto-fill, minmax(...))'. This allows the grid to automatically adjust the number of columns based on the available viewport width, preventing items from stretching when the user zooms out.
- Reduced padding, margins, and image sizes within the item cards to create a more condensed and cleaner appearance, utilizing space more effectively.