### PR TITLE
style: Refine card icon layout and alignment

### DIFF
--- a/database.html
+++ b/database.html
@@ -239,9 +239,9 @@
                         <div class="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
                             ${itemsToRender.map(card => `
                                 <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 flex flex-col transition-all hover:border-purple-500/50 hover:shadow-2xl hover:shadow-purple-500/10">
-                                     <div class="flex items-start mb-3">
-                                        <img src="Sprites/Cards/${card.Slot}.png" alt="${card.Slot} Card" class="w-12 h-12 rounded-md mr-2 flex-shrink-0" onerror="this.onerror=null;this.src='https://placehold.co/40x40/1f2937/a855f7?text=C'; this.classList.add('bg-gray-700');">
-                                        <div class="flex-1">
+                                     <div class="flex items-center mb-3">
+                                        <img src="Sprites/Cards/${card.Slot}.png" alt="${card.Slot} Card" class="w-14 h-14 rounded-md mr-0 flex-shrink-0" onerror="this.onerror=null;this.src='https://placehold.co/40x40/1f2937/a855f7?text=C'; this.classList.add('bg-gray-700');">
+                                        <div class="flex-1 ml-4">
                                             <p class="text-xs font-bold uppercase text-purple-400">${card.Affix}</p>
                                             <h3 class="font-bold text-lg text-white leading-tight">${card.Name}</h3>
                                             <div class="mt-1">


### PR DESCRIPTION
This commit further refines the card icon's presentation in the database view based on additional user feedback.

The following adjustments have been made to achieve a more polished and balanced layout:
- The flex container for the icon and text has been changed to `items-center` to ensure the icon is vertically centered with the card name.
- The icon size has been increased to `w-14 h-14` for better visibility.
- The icon's right margin has been removed (`mr-0`), and a left margin (`ml-4`) has been added to the text container to create the desired spacing.