### PR TITLE
feat: Display artifact set images in the database

### DIFF
--- a/database.html
+++ b/database.html
@@ -266,7 +266,7 @@
                             ${itemsToRender.map(artifact => `
                                 <div class="relative bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 transition-all hover:border-teal-500/50 hover:shadow-2xl hover:shadow-teal-500/10">
                                     <img src="Sprites/Artifacts/${artifact.SetName}.png" alt="${artifact.SetName} Set"
-                                         class="absolute top-4 right-4 w-14 h-14 object-contain opacity-75"
+                                         class="absolute top-4 right-4 w-20 h-20 object-contain opacity-100"
                                          onerror="this.style.display='none'">
                                     <div class="mr-20">
                                         <h3 class="font-bold text-xl text-white mb-3">${artifact.SetName} Set</h3>


### PR DESCRIPTION
This commit implements the feature to display artifact set images in the top-right corner of each artifact card in the database.

- The `renderArtifactsList` function in `database.html` was updated to include an `<img>` tag for each artifact set.
- The image `src` is dynamically generated based on the artifact's `SetName`.
- Tailwind CSS classes are used to position and style the images, with the size set to `w-20 h-20` and opacity to `opacity-100` per the user's requests.
- An `onerror` attribute is included to gracefully handle missing images.
- The layout of the artifact card was adjusted to prevent text from overlapping with the image.
- The artifact image `Sprites/Artifacts/Novice.png` was renamed to `Sprites/Artifacts/Pioneer.png` to match the `SetName` in the data, ensuring it is displayed correctly.