### PR TITLE
Feat: Link equipment sprites in the database

### DIFF
--- a/database.html
+++ b/database.html
@@ -199,7 +199,7 @@
                             ${itemsToRender.map(item => `
                                 <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 flex flex-col transition-all hover:border-indigo-500/50 hover:shadow-2xl hover:shadow-indigo-500/10">
                                     <div class="flex items-start mb-3">
-                                        <img src="https://placehold.co/64x64/1f2937/7c3aed?text=${item.Name.substring(0,1)}" alt="${item.Name}" class="w-12 h-12 rounded-md bg-gray-700 mr-4 flex-shrink-0">
+                                        <img src="Sprites/Equipment/${item.SpriteId}.png" alt="${item.Name}" class="w-12 h-12 rounded-md bg-gray-700 mr-4 flex-shrink-0" onerror="this.onerror=null;this.src='https.placehold.co/64x64/1f2937/7c3aed?text=${item.Name.substring(0,1)}';">
                                         <div class="flex-1">
                                             <h3 class="font-bold text-lg text-white leading-tight">${item.Name}</h3>
                                             <div class="mt-1 flex items-center flex-wrap">


### PR DESCRIPTION
This commit links the equipment sprites to the equipment database.

- Modifies `database.html` to dynamically generate the `src` attribute for equipment images based on the `SpriteId` from `Equipment.js`.
- The image path is now `Sprites/Equipment/{SpriteId}.png`.
- Adds an `onerror` attribute to the `img` tag to fall back to a placeholder image if the sprite is not found, preventing broken image icons.