### PR TITLE
feat: Add boss monster indicator and tooltip

### DIFF
--- a/database.html
+++ b/database.html
@@ -161,6 +161,17 @@
                         .replace(/\n/g, '<br>');
                 }
 
+                function getMonsterNameHTML(monsterName, monsterData) {
+                    const monster = monsterData.find(m => m.MonsterName === monsterName);
+                    if (monster && monster.IsBoss) {
+                        return `<span class="inline-flex items-center">
+                                    <svg class="w-4 h-4 mr-1.5 text-red-400 boss-icon" data-tooltip-text="Boss Monster" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15.93c-3.32-.15-6-2.9-6-6.22 0-1.12.3-2.16.82-3.07L12 15l-1 3.93zm6.44-3.19c-.43.92-1.05 1.7-1.82 2.3L12 12l6-4.18c.39.91.59 1.91.59 2.96 0 1.4-.35 2.7-.95 3.81zM12 4c1.01 0 1.95.24 2.8.65L12 8 9.2 4.65C10.05 4.24 10.99 4 12 4z"/></svg>
+                                    ${monsterName}
+                                </span>`;
+                    }
+                    return monsterName;
+                }
+
                 function renderSources(item, themeColor) {
                     if (!item.Source) return '';
 
@@ -173,14 +184,22 @@
                     let sourcesHtml = `<div class="mt-4 pt-4 border-t border-gray-700/50 text-xs text-gray-400">`;
 
                     if (sources.length === 1 && sources[0] !== '') {
-                         sourcesHtml += `<p>Source: <span class="monster-link font-semibold text-${themeColor}-400 cursor-pointer" data-monster-name="${sources[0]}" data-droprate="${droprates[0] || ''}" data-location="${locations[0] || ''}">${sources[0]}</span></p>`;
+                        const source = sources[0];
+                        const monsterName = source.replace(/^(Rune - |Gem - |Relic - |Scroll - )/, '');
+                        const prefixMatch = source.match(/^(Rune - |Gem - |Relic - |Scroll - )/);
+                        const prefix = prefixMatch ? prefixMatch[0] : '';
+                        const displayName = prefix + getMonsterNameHTML(monsterName, monsterData);
+                        sourcesHtml += `<p>Source: <span class="monster-link font-semibold text-${themeColor}-400 cursor-pointer" data-monster-name="${monsterName}" data-droprate="${droprates[0] || ''}" data-location="${locations[0] || ''}">${displayName}</span></p>`;
                     } else {
                         sourcesHtml += '<p class="text-xs text-gray-500 uppercase font-semibold mb-1">Sources</p><ul class="grid grid-cols-2 gap-x-4 text-sm list-disc list-inside">';
                         sources.forEach((source, index) => {
                             if (source === '') return;
                             const monsterName = source.replace(/^(Rune - |Gem - |Relic - |Scroll - )/, '');
+                            const prefixMatch = source.match(/^(Rune - |Gem - |Relic - |Scroll - )/);
+                            const prefix = prefixMatch ? prefixMatch[0] : '';
+                            const displayName = prefix + getMonsterNameHTML(monsterName, monsterData);
                             sourcesHtml += `<li class="break-words">
-                                <span class="monster-link font-semibold text-${themeColor}-400 cursor-pointer" data-monster-name="${monsterName}" data-droprate="${droprates[index] || ''}" data-location="${locations[index] || ''}">${source}</span>
+                                <span class="monster-link font-semibold text-${themeColor}-400 cursor-pointer" data-monster-name="${monsterName}" data-droprate="${droprates[index] || ''}" data-location="${locations[index] || ''}">${displayName}</span>
                             </li>`;
                         });
                         sourcesHtml += '</ul>';
@@ -252,7 +271,7 @@
                                         <p class="text-sm font-mono">${parseStats(card.Stats)}</p>
                                     </div>
                                      <div class="mt-auto pt-4 border-t border-gray-700/50 text-xs text-gray-400 space-y-1">
-                                        <p>Source: <span class="monster-link font-semibold text-purple-400 cursor-pointer" data-monster-name="${card.Source}" data-droprate="${formatCardDroprate(card.Droprate)}" data-location="${card.Location}">${card.Source}</span></p>
+                                        <p>Source: <span class="monster-link font-semibold text-purple-400 cursor-pointer" data-monster-name="${card.Source}" data-droprate="${formatCardDroprate(card.Droprate)}" data-location="${card.Location}">${getMonsterNameHTML(card.Source, monsterData)}</span></p>
                                     </div>
                                 </div>
                             `).join('')}
@@ -300,7 +319,7 @@
                                 <tbody>
                                     ${itemsToRender.map((monster, index) => `
                                         <tr class="border-t border-gray-700/50 ${index % 2 === 0 ? 'bg-black/10' : ''}">
-                                            <td class="p-4 font-medium text-white">${monster.MonsterName}</td>
+                                            <td class="p-4 font-medium text-white">${getMonsterNameHTML(monster.MonsterName, itemsToRender)}</td>
                                             <td class="p-4 text-gray-300">${monster.Level}</td>
                                             <td class="p-4 text-gray-300">${monster.Element}</td>
                                             <td class="p-4 text-gray-300">${monster.Map}</td>
@@ -429,13 +448,16 @@
 
                 // Tooltip logic (delegated to the content container)
                 document.getElementById('content-container').addEventListener('mouseover', (e) => {
-                    if (e.target.classList.contains('monster-link')) {
-                        const monsterName = e.target.getAttribute('data-monster-name');
-                        const droprate = e.target.getAttribute('data-droprate');
-                        const location = e.target.getAttribute('data-location');
+                    const target = e.target.closest('.monster-link, .set-tooltip, .boss-icon');
+                    if (!target) return;
+
+                    if (target.classList.contains('monster-link')) {
+                        const monsterName = target.getAttribute('data-monster-name');
+                        const droprate = target.getAttribute('data-droprate');
+                        const location = target.getAttribute('data-location');
                         const monsterInfo = monsterData.find(m => m.MonsterName === monsterName);
 
-                        let content = `<h4 class="font-bold text-white text-base mb-2">${monsterName}</h4>`;
+                        let content = `<h4 class="font-bold text-white text-base mb-2">${getMonsterNameHTML(monsterName, monsterData)}</h4>`;
                         let detailsFound = false;
 
                         if (monsterInfo) {
@@ -458,9 +480,9 @@
 
                         tooltip.innerHTML = content;
                         tooltip.style.display = 'block';
-                    } else if (e.target.classList.contains('set-tooltip')) {
-                        const setName = e.target.getAttribute('data-set-name');
-                        const setBonus = decodeURIComponent(e.target.getAttribute('data-set-bonus'));
+                    } else if (target.classList.contains('set-tooltip')) {
+                        const setName = target.getAttribute('data-set-name');
+                        const setBonus = decodeURIComponent(target.getAttribute('data-set-bonus'));
 
                         if (setBonus) {
                             let content = `<h4 class="font-bold text-white text-base mb-2">${setName} Set Bonus</h4>`;
@@ -468,11 +490,18 @@
                             tooltip.innerHTML = content;
                             tooltip.style.display = 'block';
                         }
+                    } else if (target.classList.contains('boss-icon')) {
+                        const tooltipText = target.getAttribute('data-tooltip-text');
+                        if (tooltipText) {
+                            tooltip.innerHTML = `<p>${tooltipText}</p>`;
+                            tooltip.style.display = 'block';
+                        }
                     }
                 });
 
                 document.getElementById('content-container').addEventListener('mouseout', (e) => {
-                    if (e.target.classList.contains('monster-link') || e.target.classList.contains('set-tooltip')) {
+                    const target = e.target.closest('.monster-link, .set-tooltip, .boss-icon');
+                     if (target) {
                         tooltip.style.display = 'none';
                     }
                 });


### PR DESCRIPTION
This commit introduces a visual indicator for boss monsters in the database.

- A devil icon is now displayed next to the name of any monster with the "IsBoss": true property.
- Hovering over the icon reveals a tooltip with the text "Boss Monster".
- This change is applied consistently across the Equipment, Artifacts, Cards, and Monsters database views.
- The `renderSources`, `renderCardsList`, and `renderMonstersList` functions in `database.html` have been updated to support this new functionality.
- A new helper function, `getMonsterNameHTML`, has been created to centralize the logic for generating the monster name HTML, including the boss icon.