### PR TITLE
feat: Standardize 'Sources' divider on Cards page

### DIFF
--- a/database.html
+++ b/database.html
@@ -270,8 +270,8 @@
                                         <p class="text-xs text-gray-500 uppercase font-semibold">Stats</p>
                                         <p class="text-sm font-mono">${parseStats(card.Stats)}</p>
                                     </div>
-                                     <div class="mt-auto pt-4 border-t border-gray-700/50 text-xs text-gray-400 space-y-1">
-                                        <p>Source: <span class="monster-link font-semibold text-purple-400 cursor-pointer" data-monster-name="${card.Source}" data-droprate="${formatCardDroprate(card.Droprate)}" data-location="${card.Location}">${getMonsterNameHTML(card.Source, monsterData)}</span></p>
+                                    <div class="mt-auto">
+                                        ${renderSources(card, 'purple')}
                                     </div>
                                 </div>
                             `).join('')}


### PR DESCRIPTION
The 'Sources' divider on the Cards page was inconsistent with the Equipment and Artifacts pages.

This change updates the `renderCardsList` function in `database.html` to use the shared `renderSources` helper function. This ensures a consistent appearance for the 'Sources' section across all relevant pages while maintaining the unique 'purple' theme color for the Cards page.