### PR TITLE
refactor: Standardize 'Sources' divider and list format

### DIFF
--- a/database.html
+++ b/database.html
@@ -176,34 +176,42 @@
                     if (!item.Source) return '';
 
                     const sources = item.Source.split('\n');
+                    // Let's count non-empty sources to determine the label and grid
+                    const nonEmptySources = sources.filter(s => s.trim() !== '');
+                    if (nonEmptySources.length === 0) return '';
+
                     const droprates = item.Droprate ? item.Droprate.split('\n') : [];
                     const locations = item.Location ? item.Location.split('\n') : [];
 
-                    if (sources.length === 0) return '';
-
                     let sourcesHtml = `<div class="mt-4 pt-4 border-t border-gray-700/50 text-xs text-gray-400">`;
 
-                    if (sources.length === 1 && sources[0] !== '') {
-                        const source = sources[0];
+                    const label = nonEmptySources.length === 1 ? 'Source' : 'Sources';
+                    sourcesHtml += `<p class="text-xs text-gray-500 uppercase font-semibold mb-1">${label}</p>`;
+
+                    // For multiple sources, use a 2-column grid. Otherwise, a single column list.
+                    const gridClass = nonEmptySources.length > 1 ? 'grid grid-cols-2 gap-x-4' : '';
+                    sourcesHtml += `<ul class="${gridClass} text-sm list-disc list-inside">`;
+
+                    sources.forEach((source, index) => {
+                        if (source.trim() === '') return; // Skip empty lines
+
                         const monsterName = source.replace(/^(Rune - |Gem - |Relic - |Scroll - )/, '');
                         const prefixMatch = source.match(/^(Rune - |Gem - |Relic - |Scroll - )/);
                         const prefix = prefixMatch ? prefixMatch[0] : '';
                         const displayName = prefix + getMonsterNameHTML(monsterName, monsterData);
-                        sourcesHtml += `<p>Source: <span class="monster-link font-semibold text-${themeColor}-400 cursor-pointer" data-monster-name="${monsterName}" data-droprate="${droprates[0] || ''}" data-location="${locations[0] || ''}">${displayName}</span></p>`;
-                    } else {
-                        sourcesHtml += '<p class="text-xs text-gray-500 uppercase font-semibold mb-1">Sources</p><ul class="grid grid-cols-2 gap-x-4 text-sm list-disc list-inside">';
-                        sources.forEach((source, index) => {
-                            if (source === '') return;
-                            const monsterName = source.replace(/^(Rune - |Gem - |Relic - |Scroll - )/, '');
-                            const prefixMatch = source.match(/^(Rune - |Gem - |Relic - |Scroll - )/);
-                            const prefix = prefixMatch ? prefixMatch[0] : '';
-                            const displayName = prefix + getMonsterNameHTML(monsterName, monsterData);
-                            sourcesHtml += `<li class="break-words">
-                                <span class="monster-link font-semibold text-${themeColor}-400 cursor-pointer" data-monster-name="${monsterName}" data-droprate="${droprates[index] || ''}" data-location="${locations[index] || ''}">${displayName}</span>
-                            </li>`;
-                        });
-                        sourcesHtml += '</ul>';
-                    }
+
+                        let droprate = droprates[index] || '';
+                        // Cards have a special droprate format. We identify cards by their theme color.
+                        if (themeColor === 'purple') {
+                            droprate = formatCardDroprate(droprate);
+                        }
+
+                        sourcesHtml += `<li class="break-words">
+                            <span class="monster-link font-semibold text-${themeColor}-400 cursor-pointer" data-monster-name="${monsterName}" data-droprate="${droprate}" data-location="${locations[index] || ''}">${displayName}</span>
+                        </li>`;
+                    });
+                    sourcesHtml += '</ul>';
+
                     sourcesHtml += '</div>';
                     return sourcesHtml;
                 }


### PR DESCRIPTION
The 'Sources' divider was inconsistent across different pages, and the display of single sources for cards did not match user requirements.

This change refactors the `renderSources` function to create a unified and consistent display for the 'Sources' section. The function now correctly handles both single and multiple sources by displaying them in a bulleted list below the divider line.

This ensures a consistent user experience across the Equipment, Artifacts, and Cards pages while preserving the unique styling and formatting for each section.