### PR TITLE
refactor: Colorize monster elements in tooltips

### DIFF
--- a/database.html
+++ b/database.html
@@ -153,6 +153,23 @@
             try {
                 // --- UTILITY FUNCTIONS ---
 
+                const elementColors = {
+                    "Neutral": "#FFFFFFFF",
+                    "Poison": "#8CD470FF",
+                    "Holy": "#FCE9EBFF",
+                    "Shadow": "#755E94FF",
+                    "Fire": "#FF7026FF",
+                    "Water": "#79D7FDFF",
+                    "Wind": "#FFC701FF",
+                    "Earth": "#BB7B2FFF",
+                    "Undead": "#C85AE0FF",
+                };
+
+                function colorizeElement(element) {
+                    const color = elementColors[element] || elementColors['Neutral'];
+                    const hexColor = color.substring(1, 7); // Extract RRGGBB from #RRGGBBAA
+                    return `<span style="color:#${hexColor};">${element}</span>`;
+                }
                 function parseStats(statString) {
                     if (!statString) return '<span class="text-gray-500">N/A</span>';
                     return statString
@@ -470,7 +487,7 @@
 
                         if (monsterInfo) {
                             content += `<p><strong>Level:</strong> ${monsterInfo.Level}</p>
-                                      <p><strong>Element:</strong> ${monsterInfo.Element}</p>`;
+                                      <p><strong>Element:</strong> ${colorizeElement(monsterInfo.Element)}</p>`;
                             detailsFound = true;
                         }
                         if (droprate && droprate !== 'null') {


### PR DESCRIPTION
This change introduces color-coding for monster elements in the tooltip, similar to how elements are displayed in the Card database.

- Added an `elementColors` object to map element names to their corresponding hex color codes.
- Created a `colorizeElement` helper function to generate a styled `<span>` for the element.
- Updated the tooltip generation logic to use the new function, ensuring the monster's element is correctly colored.