### PR TITLE
This commit implements a feature that allows users to click on a mons…

### DIFF
--- a/database.html
+++ b/database.html
@@ -699,6 +699,18 @@
                     }
                 });
 
+                // Click handler for monster links in sources
+                document.body.addEventListener('click', e => {
+                    const monsterLink = e.target.closest('.monster-link');
+                    if (monsterLink) {
+                        const monsterName = monsterLink.dataset.monsterName;
+                        if (monsterName) {
+                            window.location.hash = 'monsters';
+                            openMonsterModal(monsterName);
+                        }
+                    }
+                });
+
 
                 // Global Tooltip Logic
                 document.body.addEventListener('mouseover', (e) => {


### PR DESCRIPTION
…ter's name in the "Sources" section of an equipment's details.

When a monster name is clicked, the application now navigates to the "Monsters" database page and automatically opens the information panel for that specific monster. This is achieved by adding a global click event listener that handles the navigation and triggers the existing modal functionality.