### PR TITLE
Feat: Prevent navigation when opening monster modal

### DIFF
--- a/database.html
+++ b/database.html
@@ -718,7 +718,6 @@
                     if (monsterLink) {
                         const monsterName = monsterLink.dataset.monsterName;
                         if (monsterName) {
-                            window.location.hash = 'monsters';
                             openMonsterModal(monsterName);
                         }
                     }


### PR DESCRIPTION
Removes the `window.location.hash` update from the monster link click handler.

Previously, clicking a monster's name in an item's "Sources" list would navigate the user to the main "Monsters" database page before opening the monster's detail modal.

This change modifies the event listener to only open the modal, keeping the user on their current page. This provides a smoother and less disorienting user experience.