### PR TITLE
feat: Make database headers sticky

### DIFF
--- a/database.html
+++ b/database.html
@@ -67,11 +67,11 @@
     <div id="sidebar"></div>
 
     <!-- Main Content -->
-    <main id="main-content" class="p-4 md:p-8">
+    <main id="main-content" class="px-4 md:px-8">
             <div id="content-container">
                 <!-- Equipment Content (Visible by default) -->
                 <section id="equipment" class="content-section">
-                    <div class="flex flex-wrap items-center gap-4 mb-6">
+                    <div class="sticky top-0 z-10 bg-gray-900 py-4 flex flex-wrap items-center gap-4 mb-6">
                         <h1 class="text-3xl font-bold text-white">Equipment</h1>
                         <div class="search-wrapper relative">
                             <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
@@ -90,7 +90,7 @@
 
                 <!-- Cards Content (Hidden by default) -->
                 <section id="cards" class="content-section hidden">
-                     <div class="flex flex-wrap items-center gap-4 mb-6">
+                     <div class="sticky top-0 z-10 bg-gray-900 py-4 flex flex-wrap items-center gap-4 mb-6">
                         <h1 class="text-3xl font-bold text-white">Cards</h1>
                         <div class="search-wrapper relative">
                             <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
@@ -109,7 +109,7 @@
 
                 <!-- Artifacts Content (Hidden by default) -->
                 <section id="artifacts" class="content-section hidden">
-                    <div class="flex items-center mb-6">
+                    <div class="sticky top-0 z-10 bg-gray-900 py-4 flex items-center mb-6">
                         <h1 class="text-3xl font-bold text-white">Artifacts</h1>
                         <div class="search-wrapper relative ml-4">
                             <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
@@ -123,7 +123,7 @@
 
                 <!-- Monsters Content (Hidden by default) -->
                 <section id="monsters" class="content-section hidden">
-                    <div class="flex items-center mb-6">
+                    <div class="sticky top-0 z-10 bg-gray-900 py-4 flex items-center mb-6">
                         <h1 class="text-3xl font-bold text-white">Monsters</h1>
                         <div class="search-wrapper relative ml-4">
                             <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">


### PR DESCRIPTION
The database headers for Equipment, Cards, Artifacts, and Monsters now remain at the top of the viewport when scrolling.

This was achieved by applying Tailwind CSS's `sticky` positioning to the header container of each section. A background color and z-index were also added to ensure the header is opaque and appears above the scrolling content.

The top padding on the main content area was removed to allow the sticky headers to anchor correctly to the top of the viewport.