### PR TITLE
Feat: Implement scroll-to-item and highlight on loot click

### DIFF
--- a/database.html
+++ b/database.html
@@ -50,6 +50,15 @@
         .search-input.expanded {
             width: 256px; /* w-64 */
         }
+        @keyframes highlight-glow {
+            0% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7); }
+            50% { box-shadow: 0 0 20px 10px rgba(59, 130, 246, 0); }
+            100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
+        }
+        .highlight-effect {
+            animation: highlight-glow 2s ease-out;
+            border-color: rgba(59, 130, 246, 0.8) !important; /* Use important to override existing styles */
+        }
         /* Custom select styling */
         .filter-select {
             -webkit-appearance: none;
@@ -332,7 +341,7 @@
                     container.innerHTML = `
                         <div class="grid grid-cols-[repeat(auto-fill,minmax(420px,1fr))] gap-4">
                             ${itemsToRender.map(item => `
-                                <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 flex flex-col transition-all hover:border-indigo-500/50 hover:shadow-2xl hover:shadow-indigo-500/10">
+                                <div data-item-name="${item.Name}" class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 flex flex-col transition-all hover:border-indigo-500/50 hover:shadow-2xl hover:shadow-indigo-500/10">
                                     <div class="flex items-start mb-3">
                                         <img src="Sprites/Equipment/${item.SpriteId}.png" alt="${item.Name}" class="w-12 h-12 rounded-md bg-gray-700 mr-4 flex-shrink-0" onerror="this.onerror=null;this.src='https.placehold.co/64x64/1f2937/7c3aed?text=${item.Name.substring(0,1)}';">
                                         <div class="flex-1">
@@ -371,9 +380,9 @@
                     container.innerHTML = `
                         <div class="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
                             ${itemsToRender.map(card => `
-                                <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 flex flex-col transition-all hover:border-purple-500/50 hover:shadow-2xl hover:shadow-purple-500/10">
+                                <div data-item-name="${card.Name}" class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 flex flex-col transition-all hover:border-purple-500/50 hover:shadow-2xl hover:shadow-purple-500/10">
                                      <div class="flex items-center mb-3">
-                                        <img src="Sprites/Cards/${card.Slot}.png" alt="${card.Slot} Card" class="w-14 h-14 rounded-md mr-0 flex-shrink-0" onerror="this.onerror=null;this.src='https://placehold.co/40x40/1f2937/a855f7?text=C'; this.classList.add('bg-gray-700');">
+                                        <img src="Sprites/Cards/${card.Slot}.png" alt="${card.Slot} Card" class="w-14 h-14 rounded-md mr-0 flex-shrink-0" onerror="this.onerror=null;this.src='https.placehold.co/40x40/1f2937/a855f7?text=C'; this.classList.add('bg-gray-700');">
                                         <div class="flex-1 ml-4">
                                             <p class="text-xs font-bold uppercase text-purple-400">${card.Affix}</p>
                                             <h3 class="font-bold text-lg text-white leading-tight">${card.Name}</h3>
@@ -400,7 +409,7 @@
                     container.innerHTML = `
                         <div class="grid grid-cols-[repeat(auto-fill,minmax(400px,1fr))] gap-4">
                             ${itemsToRender.map(artifact => `
-                                <div class="relative bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 transition-all hover:border-teal-500/50 hover:shadow-2xl hover:shadow-teal-500/10">
+                                <div data-item-name="${artifact.SetName}" class="relative bg-gray-800/70 rounded-lg border border-gray-700/50 p-4 transition-all hover:border-teal-500/50 hover:shadow-2xl hover:shadow-teal-500/10">
                                     <img src="Sprites/Artifacts/${artifact.SetName}.png" alt="${artifact.SetName} Set"
                                          class="absolute top-4 right-4 w-20 h-20 object-contain opacity-100"
                                          onerror="this.style.display='none'">
@@ -616,8 +625,10 @@
 
                 // --- HASH-BASED NAVIGATION ---
                 let pendingSearch = null; // Variable to hold search info during navigation
+                let pendingHighlight = null; // Variable to hold highlight info during navigation
 
                 function showSectionBasedOnHash() {
+                    console.log('showSectionBasedOnHash triggered. pendingHighlight is:', pendingHighlight);
                     let targetId = window.location.hash.substring(1);
                     if (!targetId || !document.getElementById(targetId)) {
                         targetId = 'equipment';
@@ -632,15 +643,27 @@
                         section.classList.toggle('hidden', section.id !== targetId);
                     });
 
-                    // If there's a pending search after a navigation, execute it now.
-                    if (pendingSearch && document.getElementById(pendingSearch.searchId)) {
-                        const searchInput = document.getElementById(pendingSearch.searchId);
-                        if (searchInput) {
-                            searchInput.value = pendingSearch.value;
-                            searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-                            searchInput.dispatchEvent(new Event('keyup', { bubbles: true }));
+                    // If there's a pending highlight after a navigation, execute it now.
+                    if (pendingHighlight && pendingHighlight.itemName) {
+                        // Need to escape special characters for querySelector, especially quotes.
+                        const itemName = pendingHighlight.itemName.replace(/"/g, '\\"');
+                        const sectionElement = document.getElementById(targetId);
+
+                        if (!sectionElement) {
+                            pendingHighlight = null;
+                            return;
                         }
-                        pendingSearch = null; // Reset after use
+                        const targetElement = sectionElement.querySelector(`[data-item-name="${itemName}"]`);
+
+                        if (targetElement) {
+                            targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                            targetElement.classList.add('highlight-effect');
+
+                            setTimeout(() => {
+                                targetElement.classList.remove('highlight-effect');
+                            }, 2000); // Highlight duration
+                        }
+                        pendingHighlight = null; // Reset after use
                     }
                 }
 
@@ -732,23 +755,22 @@
 
                         if (itemName && itemType) {
                             const sectionMap = {
-                                'Equipment': { hash: 'equipment', searchId: 'equipment-search' },
-                                'Card': { hash: 'cards', searchId: 'cards-search' },
-                                'Artifact': { hash: 'artifacts', searchId: 'artifacts-search' }
+                                'Equipment': { hash: 'equipment' },
+                                'Card': { hash: 'cards' },
+                                'Artifact': { hash: 'artifacts' }
                             };
 
                             const section = sectionMap[itemType];
                             if (section) {
                                 closeMonsterModal();
 
-                                // Set up the pending search object
-                                pendingSearch = {
-                                    searchId: section.searchId,
-                                    value: itemName
+                                // Set up the pending highlight object
+                                pendingHighlight = {
+                                    itemName: itemName
                                 };
+                                console.log('pendingHighlight set:', pendingHighlight);
 
-                                // Change the hash. The 'hashchange' event listener will now handle showing the
-                                // section and then executing the pending search.
+                                // Change the hash. The 'hashchange' event listener will handle scrolling and highlighting.
                                 window.location.hash = section.hash;
                             }
                         }


### PR DESCRIPTION
This commit refactors the loot drop navigation functionality. Previously, clicking a loot item would filter the target database page to show only that item. This change updates the behavior to navigate to the correct page, scroll the specific item into view, and apply a temporary highlight effect.

This provides a more intuitive user experience by directly guiding the user to the item they clicked on.