### PR TITLE
feat: Implement "Try your luck?" feature

### DIFF
--- a/.JULES_MEMORY_RECORD
+++ b/.JULES_MEMORY_RECORD
@@ -1,0 +1,1 @@
+In the stat calculator, some equipment types (e.g., 'Axe') are aliases for more general types (e.g., 'Melee Weapon'). The `statRollData` object contains these aliases, and the stat rolling logic must resolve them to find the correct stat pools.

--- a/index.html
+++ b/index.html
@@ -102,14 +102,55 @@
                 <p class="text-xs text-slate-500">Probabilities are based on the assumption of equal chances for each outcome within a stat group.</p>
             </footer>
         </div>
+
+        <!-- "Try Your Luck?" Section -->
+        <div class="max-w-4xl mx-auto mt-8">
+            <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-6 md:p-8 transition-all hover:border-purple-500/50 hover:shadow-2xl hover:shadow-purple-500/10">
+                <header class="text-center mb-6">
+                    <h2 class="text-2xl md:text-3xl font-bold text-white">Try Your Luck?</h2>
+                    <p class="text-slate-400 mt-2">Simulate monster kills to see if you get your desired equipment.</p>
+                </header>
+
+                <div class="flex flex-col items-center">
+                    <button id="luckToggleBtn" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2.5 px-6 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-purple-500">
+                        Try your luck?
+                    </button>
+                </div>
+
+                <div id="luck-section" class="hidden mt-6">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
+                        <div class="md:col-span-2">
+                            <label for="luck-equipment-search" class="block text-sm font-medium text-gray-400 mb-2">Search for an Equipment Piece</label>
+                            <input type="text" id="luck-equipment-search" list="equipment-luck-list" class="w-full bg-gray-700 border border-gray-600 rounded-md py-2.5 px-3 text-white focus:outline-none focus:ring-2 focus:ring-purple-500" placeholder="Type to search for equipment...">
+                            <datalist id="equipment-luck-list"></datalist>
+                        </div>
+                    </div>
+
+                    <div id="luck-controls" class="hidden text-center mt-4">
+                         <div class="flex items-center justify-center gap-4">
+                            <button id="rollBtn" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-5 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-green-500" disabled>
+                                Roll
+                            </button>
+                            <p class="text-slate-400">Kills: <span id="killCounter" class="font-bold text-white">0</span></p>
+                        </div>
+                        <p id="luck-item-info" class="text-xs text-slate-500 mt-2"></p>
+                    </div>
+
+                    <div id="luck-results" class="mt-6 text-center">
+                        <!-- Results will be displayed here -->
+                    </div>
+                </div>
+            </div>
+        </div>
     </main>
 
     <script src="changelog.js" defer></script>
     <script src="sidebar.js" defer></script>
+    <script src="Equipment.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             // --- DATA SETUP ---
-            const equipmentData = {
+            const statRollData = {
                 "Ranged Weapon": {
                     pools: {
                         line1: [
@@ -127,6 +168,14 @@
                     },
                     selection: ['line1', 'line23', 'line23']
                 },
+                "Axe": { "type": "Melee Weapon" },
+                "Dagger": { "type": "Melee Weapon" },
+                "Mace": { "type": "Melee Weapon" },
+                "Spear": { "type": "Melee Weapon" },
+                "Sword": { "type": "Melee Weapon" },
+                "Wand": { "type": "Melee Weapon" },
+                "Book": { "type": "Melee Weapon" },
+                "Bow": { "type": "Ranged Weapon" },
                 "Melee Weapon": {
                     pools: {
                         line1: [
@@ -204,7 +253,11 @@
                         ]
                     },
                     selection: ['line1', 'line23', 'line23']
-                }
+                },
+                 "Back": { "type": "Accessory" },
+                 "Eyewear": { "type": "Accessory" },
+                 "Head": { "type": "Accessory" },
+                 "Shield": { "type": "Accessory" },
             };
 
             let statDetails = {};
@@ -229,7 +282,8 @@
 
             // --- UI INITIALIZATION & UPDATES ---
             function init() {
-                Object.keys(equipmentData).forEach(name => {
+                const equipmentTypesForCalc = Object.keys(statRollData).filter(key => statRollData[key].pools);
+                equipmentTypesForCalc.forEach(name => {
                     const option = document.createElement('option');
                     option.value = name;
                     option.textContent = name;
@@ -244,7 +298,7 @@
             }
 
             function updateUIForEquipment(equipmentName) {
-                const equipment = equipmentData[equipmentName];
+                const equipment = statRollData[equipmentName];
                 statDetails = {}; // Clear old details
 
                 // Rebuild statDetails map for current equipment
@@ -327,7 +381,7 @@
                 const selectedStats = selectedNames.map(name => statDetails[name]);
 
                 // Custom check for weapon, which has distinct pools
-                if (equipmentData[equipmentSelect.value].selection[0] === 'line1') {
+                if (statRollData[equipmentSelect.value].selection[0] === 'line1') {
                     const line1Group = selectedStats[0].group; // will be undefined
                     const line23Groups = new Set([selectedStats[1].group, selectedStats[2].group]);
                      if (line23Groups.size < 2) {
@@ -353,13 +407,13 @@
             }
 
             function getStatsInGroup(group, equipmentName, poolName) {
-                 const equipment = equipmentData[equipmentName];
+                 const equipment = statRollData[equipmentName];
                  const pool = equipment.pools[poolName] || [];
                  return pool.filter(s => s.group === group).length;
             }
 
             function calculateProbability(equipmentName, statNames, isPerfect) {
-                const equipment = equipmentData[equipmentName];
+                const equipment = statRollData[equipmentName];
                 const stats = statNames.map(name => statDetails[name]);
 
                 let totalProb = 1;
@@ -432,6 +486,148 @@
             }
 
             init();
+
+            // --- "TRY YOUR LUCK?" FEATURE LOGIC ---
+            const luckToggleBtn = document.getElementById('luckToggleBtn');
+            const luckSection = document.getElementById('luck-section');
+            const luckSearchInput = document.getElementById('luck-equipment-search');
+            const luckDatalist = document.getElementById('equipment-luck-list');
+            const luckControls = document.getElementById('luck-controls');
+            const rollBtn = document.getElementById('rollBtn');
+            const killCounterSpan = document.getElementById('killCounter');
+            const luckItemInfo = document.getElementById('luck-item-info');
+            const luckResults = document.getElementById('luck-results');
+
+            let killCount = 0;
+            let selectedLuckItem = null;
+            let highestDropRate = 0;
+
+            function initLuckFeature() {
+                // Populate the datalist with equipment that can be rolled
+                const rollableTypes = Object.keys(statRollData);
+                const validEquipment = equipmentData.filter(item => {
+                    // Check if the item's direct type or its aliased type is in statRollData
+                    const baseType = item.Type;
+                    const aliasedType = statRollData[baseType] ? statRollData[baseType].type : null;
+                    return rollableTypes.includes(baseType) || (aliasedType && rollableTypes.includes(aliasedType));
+                });
+
+                validEquipment.forEach(item => {
+                    const option = document.createElement('option');
+                    option.value = item.Name;
+                    luckDatalist.appendChild(option);
+                });
+
+                luckToggleBtn.addEventListener('click', () => {
+                    luckSection.classList.toggle('hidden');
+                });
+
+                luckSearchInput.addEventListener('input', handleLuckEquipmentSelect);
+                rollBtn.addEventListener('click', handleRoll);
+            }
+
+            function handleLuckEquipmentSelect() {
+                const itemName = luckSearchInput.value;
+                selectedLuckItem = equipmentData.find(item => item.Name === itemName);
+
+                if (selectedLuckItem && selectedLuckItem.Droprate) {
+                    // Find the highest drop rate
+                    const droprates = selectedLuckItem.Droprate.split('\n').map(r => parseFloat(r));
+                    highestDropRate = Math.max(...droprates) / 100; // Convert to decimal for calculation
+
+                    luckItemInfo.textContent = `Selected: ${selectedLuckItem.Name} (Highest Drop Chance: ${(highestDropRate * 100).toFixed(2)}%)`;
+                    luckControls.classList.remove('hidden');
+                    rollBtn.disabled = false;
+                    luckResults.innerHTML = ''; // Clear previous results
+                    killCount = 0; // Reset counter
+                    killCounterSpan.textContent = killCount;
+                } else {
+                    luckControls.classList.add('hidden');
+                    rollBtn.disabled = true;
+                    selectedLuckItem = null;
+                    highestDropRate = 0;
+                }
+            }
+
+            function handleRoll() {
+                if (!selectedLuckItem) return;
+
+                killCount++;
+                killCounterSpan.textContent = killCount;
+
+                const didDrop = Math.random() < highestDropRate;
+
+                if (didDrop) {
+                    const rolledStats = rollStatsForItem(selectedLuckItem);
+                    luckResults.innerHTML = `
+                        <div class="bg-green-900/50 border border-green-700 text-green-300 px-4 py-4 rounded-lg">
+                            <h4 class="font-bold text-lg text-white">Success! You got the ${selectedLuckItem.Name}!</h4>
+                            <p class="mt-2">Rolled Stats:</p>
+                            <ul class="list-disc list-inside mt-1 font-mono">
+                                ${rolledStats.map(stat => `<li>${stat}</li>`).join('')}
+                            </ul>
+                        </div>`;
+                } else {
+                    luckResults.innerHTML = `
+                        <div class="bg-red-900/50 border border-red-700 text-red-300 px-4 py-3 rounded-lg">
+                            <p>You did not get the weapon you wanted from this kill.</p>
+                        </div>`;
+                }
+            }
+
+            function getRandomElement(arr) {
+                return arr[Math.floor(Math.random() * arr.length)];
+            }
+
+            function rollStatsForItem(item) {
+                // Get the rolling configuration for the item's type.
+                // `statRollData` is the configuration object defined in this script.
+                let itemConfigKey = item.Type;
+                let itemConfig = statRollData[itemConfigKey];
+
+                // Handle aliased types (e.g., "Axe" uses "Melee Weapon" config)
+                if (itemConfig && itemConfig.type) {
+                    itemConfigKey = itemConfig.type;
+                    itemConfig = statRollData[itemConfigKey];
+                }
+
+                if (!itemConfig || !itemConfig.pools) {
+                    return ["Stat rolling not configured for this item type."];
+                }
+
+                const rolledStats = [];
+                const usedGroups = new Set();
+
+                // Roll Stat 1 from line1 pool
+                const line1Pool = itemConfig.pools.line1;
+                if (!line1Pool || line1Pool.length === 0) return ["Error: line1 pool is empty."];
+                const stat1 = getRandomElement(line1Pool);
+                rolledStats.push(stat1.name);
+                if (stat1.group) usedGroups.add(stat1.group);
+
+                // Roll Stat 2 & 3 from line23 pool
+                const line23Pool = itemConfig.pools.line23;
+                if (!line23Pool) return ["Error: line23 pool is missing."];
+
+                // Filter for stat 2, excluding groups already used
+                let availablePool2 = line23Pool.filter(s => !usedGroups.has(s.group));
+                if (availablePool2.length === 0) return ["Error: Not enough stat groups for the second roll."];
+                const stat2 = getRandomElement(availablePool2);
+                rolledStats.push(stat2.name);
+                if (stat2.group) usedGroups.add(stat2.group);
+
+                // Filter for stat 3, excluding the group from stat 2
+                let availablePool3 = availablePool2.filter(s => s.group !== stat2.group);
+                if (availablePool3.length === 0) return ["Error: Not enough stat groups for the third roll."];
+                const stat3 = getRandomElement(availablePool3);
+                rolledStats.push(stat3.name);
+
+                return rolledStats;
+            }
+
+            // `equipmentData` is loaded from the external Equipment.js file.
+            // It is separate from `statRollData` which is defined in this script.
+            initLuckFeature();
         });
     </script>
 </body>


### PR DESCRIPTION
This commit introduces a new "Try your luck?" feature to the stat calculator, allowing users to simulate obtaining equipment from monster drops.

Key changes:
- Added a new UI section to `index.html` with an equipment search, a "Roll" button, and a kill counter.
- Implemented JavaScript logic to handle the simulation, including:
  - Fetching the highest drop rate for the selected item.
  - Simulating a monster kill based on the drop rate.
  - If successful, randomly rolling three stats for the item based on its type and stat pools.
- Populated a datalist with rollable equipment to guide user selection.
- Added aliases for equipment types in the `statRollData` to handle different weapon types under a common configuration.