### PR TITLE
Fix: Ensure item navigation from monster modal works correctly

### DIFF
--- a/database.html
+++ b/database.html
@@ -770,8 +770,16 @@
                                 };
                                 console.log('pendingHighlight set:', pendingHighlight);
 
-                                // Change the hash. The 'hashchange' event listener will handle scrolling and highlighting.
-                                window.location.hash = section.hash;
+                                const targetHash = `#${section.hash}`;
+                                // If we are already on the correct section, the hash won't change,
+                                // so the 'hashchange' event won't fire. We need to trigger the
+                                // highlight logic manually in this case.
+                                if (window.location.hash === targetHash) {
+                                    showSectionBasedOnHash();
+                                } else {
+                                    // Otherwise, changing the hash will trigger the event listener.
+                                    window.location.hash = section.hash;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
The previous implementation relied solely on the `hashchange` event to trigger item highlighting and scrolling. This failed when the user was already on the correct database section, as the hash would not change, and the event would not fire.

This change modifies the loot item click handler to check if the current `window.location.hash` matches the target section's hash. If they match, it calls the `showSectionBasedOnHash()` function directly to ensure the UI is updated. Otherwise, it proceeds with the hash change as before.

This ensures a consistent user experience regardless of the current navigation state.