### PR TITLE
feat: Create database converter for equipment and cards

### DIFF
--- a/Cards.js
+++ b/Cards.js
@@ -1,4 +1,4 @@
-const cardData = [
+window.cardData = [
     {
         "Name": "Angel Card",
         "CardId": "Angel",

--- a/Equipment.js
+++ b/Equipment.js
@@ -1,4 +1,4 @@
-const equipmentData = [
+window.equipmentData = [
     {
         "Name": "Abyss Shard",
         "EquipmentId": "Abyss Shard",

--- a/damage_simulator.html
+++ b/damage_simulator.html
@@ -425,6 +425,9 @@
     <script src="sidebar.js" defer></script>
     <script src="classes.js" defer></script>
     <script src="monsters.js" defer></script>
+    <script src="Equipment.js" defer></script>
+    <script src="Cards.js" defer></script>
+    <script src="database-converter.js" defer></script>
     <script src="modal.js" defer></script>
     <script src="main.js" defer></script>
 </body>

--- a/database-converter.js
+++ b/database-converter.js
@@ -1,0 +1,132 @@
+/**
+ * Parses a raw stat string from the game's data files into a structured format.
+ * @param {string | null} statsStr - The raw string containing one or more stat bonuses.
+ * @returns {Array<Object>} An array of structured stat objects.
+ */
+function parseStats(statsStr) {
+    if (!statsStr) {
+        return [];
+    }
+
+    const processedStats = [];
+    const lines = statsStr.split('\n');
+    const valueRegex = /([+-])\s*(\d+\.?\d*)\s*(%?)/;
+
+    for (const originalLine of lines) {
+        if (!originalLine.trim()) continue;
+
+        if (originalLine.includes(':')) {
+            const parts = originalLine.split(':');
+            const statName = parts[0].replace(/<[^>]*>/g, '').trim();
+            let valuesStr = parts.slice(1).join(':').replace(/<[^>]*>/g, '').trim();
+
+            const perLevelRegex = /([+-]\s*\d+\.?\d*%?)\s*per level/i;
+            const perLevelMatch = valuesStr.match(perLevelRegex);
+
+            let perLevelPart = null;
+            let basePart = valuesStr;
+
+            if (perLevelMatch) {
+                perLevelPart = perLevelMatch[1].replace(/\s/g, '');
+                basePart = valuesStr.replace(perLevelMatch[0], '').trim();
+            }
+
+            const baseValueMatch = basePart.match(valueRegex);
+            const perLevelValueMatch = perLevelPart ? perLevelPart.match(valueRegex) : null;
+
+            if (baseValueMatch || perLevelValueMatch) {
+                let finalValue = 0;
+                let finalPerLevel = 0;
+                let isPercentage = false;
+
+                if (baseValueMatch) {
+                    const baseSign = baseValueMatch[1] === '+' ? 1 : -1;
+                    const baseValue = parseFloat(baseValueMatch[2]);
+                    isPercentage = baseValueMatch[3] === '%';
+                    finalValue = baseValue * baseSign;
+                }
+
+                if (perLevelValueMatch) {
+                    const perLevelSign = perLevelValueMatch[1] === '+' ? 1 : -1;
+                    const perLevelValue = parseFloat(perLevelValueMatch[2]);
+                    if (!isPercentage) {
+                        isPercentage = perLevelValueMatch[3] === '%';
+                    }
+                    finalPerLevel = perLevelValue * perLevelSign;
+                }
+
+                if (statName === 'All Stats') {
+                    ['Str', 'Agi', 'Vit', 'Int', 'Dex', 'Luk'].forEach(s => {
+                        processedStats.push({
+                            stat: s,
+                            value: finalValue,
+                            perLevel: finalPerLevel,
+                            isPercentage: isPercentage,
+                        });
+                    });
+                } else {
+                    processedStats.push({
+                        stat: statName,
+                        value: finalValue,
+                        perLevel: finalPerLevel,
+                        isPercentage: isPercentage,
+                    });
+                }
+                continue;
+            }
+        }
+
+        const cleanedLine = originalLine.replace(/<[^>]*>/g, ' ').replace(/\s\s+/g, ' ').trim();
+        if (cleanedLine) {
+            processedStats.push({
+                stat: 'Special',
+                description: cleanedLine,
+            });
+        }
+    }
+
+    return processedStats;
+}
+
+
+/**
+ * Processes the raw equipment data to add a machine-readable 'ProcessedStats' property.
+ * @param {Array<Object>} equipmentData - The raw equipment data from Equipment.json.
+ * @returns {Array<Object>} The processed equipment data.
+ */
+function processEquipmentData(data) {
+    return data.map(item => {
+        const primary = parseStats(item.PrimaryStats);
+        const secondary = parseStats(item.SecondaryStats);
+        const setBonuses = parseStats(item.SetBonuses);
+        item.ProcessedStats = {
+            primary,
+            secondary,
+            setBonuses
+        };
+        return item;
+    });
+}
+
+/**
+ * Processes the raw card data to add a machine-readable 'ProcessedStats' property.
+ * @param {Array<Object>} cardData - The raw card data from Cards.json.
+ * @returns {Array<Object>} The processed card data.
+ */
+function processCardsData(data) {
+    return data.map(card => {
+        card.ProcessedStats = parseStats(card.Stats);
+        return card;
+    });
+}
+
+// Process data immediately when the script is loaded.
+if (typeof window.equipmentData !== 'undefined' && Array.isArray(window.equipmentData)) {
+    window.equipmentData = processEquipmentData(window.equipmentData);
+    console.log('Equipment data has been processed and converted.');
+}
+
+if (typeof window.cardData !== 'undefined' && Array.isArray(window.cardData)) {
+    window.cardData = processCardsData(window.cardData);
+    console.log('Card data has been processed and converted.');
+}


### PR DESCRIPTION
This commit introduces a new file, `database-converter.js`, which provides utility functions to parse and convert the string-based stat data from `Equipment.js` and `Cards.js` into a structured, machine-readable format.

The `parseStats` function uses regular expressions to extract stat names, values, and per-level scaling from the raw strings, while stripping HTML tags. The `processEquipmentData` and `processCardsData` functions apply this parsing to the respective datasets, adding a `ProcessedStats` property to each item.

This new, structured data will enable the upcoming Damage Builder feature to programmatically use equipment and card stats for calculations.