### PR TITLE
Fix: Apply percentage-based stats from accessories

### DIFF
--- a/main.js
+++ b/main.js
@@ -1081,7 +1081,12 @@ function calculateGearBonuses() {
     const statNameMapping = {
         'Atk': 'Bonus ATK', 'Matk': 'Bonus MATK', 'Def': 'Flat Def', 'Mdef': 'Flat Mdef',
         'Def Flat': 'Flat Def', 'Mdef Flat': 'Flat Mdef', 'Crit': 'Flat CRIT', 'Crit Damage': 'Crit Dmg %',
-        'Atk Spd %': 'AtkSpeed %', 'Cast Spd %': 'CastSpeed %', 'Block': 'Block %'
+        'Atk Spd %': 'AtkSpeed %', 'Cast Spd %': 'CastSpeed %', 'Block': 'Block %',
+        // Additions for percentage stats from accessories
+        'Atk %': 'ATK %',
+        'Matk %': 'MATK %',
+        'Crit Damage %': 'Crit Dmg %',
+        'Crit Rate %': 'Crit Rate %'
     };
     const weaponTypes = ['Sword', 'Dagger', 'Axe', 'Mace', 'Bow', 'Wand', 'Spear', 'Book'];
 


### PR DESCRIPTION
Updates the `statNameMapping` object in `main.js` to correctly map the percentage-based stat names generated by the data parser (e.g., 'Atk %', 'Crit Damage %').

This ensures that these bonuses are recognized and included in the final damage calculations, resolving the issue where they were previously ignored.