### PR TITLE
Feat: Implement dynamic weapon stance and element system

### DIFF
--- a/damage_simulator.html
+++ b/damage_simulator.html
@@ -251,6 +251,8 @@
             </div>
         </div>
 
+        <div id="weapon-stance-display" class="text-center text-lg font-semibold text-indigo-400 mb-6"></div>
+
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <!-- Player Stats Column -->
             <div class="lg:col-span-1 space-y-6">
@@ -332,12 +334,6 @@
                             <label for="p_weapon_bad_offhand">Off-Hand (BAD)</label>
                             <select id="p_weapon_bad_offhand" class="recalculate filter-select">
                                 <option value="0.9">Unarmed</option> <option value="1" selected>Dagger</option> <option value="1">Twinblade</option> <option value="1.1">Sword</option> <option value="1.1">Book</option> <option value="1.15">Mace</option> <option value="1.15">Instrument</option> <option value="1.2">Spear</option> <option value="1.2">Wand</option> <option value="1.2">Scythe</option> <option value="1.3">Axe</option> <option value="1.4">Bow</option> <option value="1.4">Pistol</option>
-                            </select>
-                        </div>
-                        <div class="input-group">
-                            <label for="p_element">Element Conv.</label>
-                            <select id="p_element" class="recalculate filter-select">
-                                <option value="Neutral">Neutral</option> <option value="Poison">Poison</option> <option value="Shadow">Shadow</option> <option value="Holy">Holy</option> <option value="Fire" selected>Fire</option> <option value="Water">Water</option> <option value="Wind">Wind</option> <option value="Earth">Earth</option> <option value="Undead">Undead</option>
                             </select>
                         </div>
                         <div class="flex items-center justify-between">


### PR DESCRIPTION
- Removes the static "Weapon Setup" UI component and the "Element Conv." dropdown from the Damage Simulator.
- Implements logic to dynamically determine the player's weapon stance based on equipped gear in the main-hand and off-hand slots.
- The following stances are now supported:
  - Unarmed: No weapon equipped.
  - Two-Handed Stance: Main-hand weapon equipped, off-hand empty. Applies a 1.25x damage bonus.
  - One-Handed Stance: Main-hand weapon and off-hand shield equipped.
  - Dual-Wield Stance: Both main-hand and off-hand have weapons equipped. Calculates an averaged Base Attack Delay (BAD) with a penalty.
- Implements logic to derive the weapon's attack element from equipped cards (e.g., "Enchant Weapon with Holy Element"). The main-hand weapon's card has priority.
- Adds a new UI element to display the currently active weapon stance.
- Updates all relevant damage and stat calculations (ATK, MATK, ASPD) to use the new dynamic stance, BAD, and element values.
- Updates the data converter to correctly parse elemental enchantments from card stat strings.