### PR TITLE
feat: Implement Artifact Sets feature in Damage Simulator

### DIFF
--- a/damage_simulator.html
+++ b/damage_simulator.html
@@ -243,11 +243,28 @@
         </header>
 
         <div id="gear-builder" class="mb-8">
-            <div class="grid grid-cols-2 gap-x-4 max-w-lg mx-auto">
-                <!-- Left Column -->
-                <div id="gear-column-left" class="space-y-2"></div>
-                <!-- Right Column -->
-                <div id="gear-column-right" class="space-y-2"></div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-5xl mx-auto">
+                <!-- Gear Container -->
+                <div class="md:col-span-2 grid grid-cols-2 gap-4">
+                    <div id="gear-column-left" class="space-y-2"></div>
+                    <div id="gear-column-right" class="space-y-2"></div>
+                </div>
+
+                <!-- Artifact Column -->
+                <div id="artifact-column" class="space-y-2 md:col-span-1">
+                     <div class="bg-gray-800 rounded-md border border-gray-700 p-3 space-y-3 h-full">
+                        <h3 class="text-center font-semibold text-white">Artifact Set</h3>
+                        <select id="artifact-set-select" class="filter-select w-full">
+                            <option value="">-- No Set --</option>
+                        </select>
+                        <div id="artifact-pieces-container" class="space-y-2">
+                            <!-- Artifact pieces will be generated here by JS -->
+                        </div>
+                        <div id="artifact-set-bonus-display" class="text-xs text-gray-400 mt-2 p-2 bg-gray-900/50 rounded-md border border-gray-700/50 hidden">
+                            <!-- Set bonus description will be shown here -->
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -467,6 +484,7 @@
     <script src="monsters.js" defer></script>
     <script src="Equipment.js" defer></script>
     <script src="Cards.js" defer></script>
+    <script src="Artifacts.js" defer></script>
     <!-- Converter must run after data is loaded -->
     <script src="database-converter.js" defer></script>
     <!-- Main logic that depends on processed data -->

--- a/database-converter.js
+++ b/database-converter.js
@@ -139,6 +139,21 @@ function processCardsData(data) {
     });
 }
 
+/**
+ * Processes the raw artifact data to add a machine-readable 'ProcessedStats' property.
+ * @param {Array<Object>} artifactData - The raw artifact data from Artifacts.js.
+ * @returns {Array<Object>} The processed artifact data.
+ */
+function processArtifactData(data) {
+    return data.map(item => {
+        item.ProcessedStats = {
+            perRefine: parseStats(item.PerRefineBonus),
+            fullSet: parseStats(item.FullSetBonus)
+        };
+        return item;
+    });
+}
+
 function processAllData() {
     console.log("--- Starting data processing ---");
     if (typeof window.equipmentData !== 'undefined' && Array.isArray(window.equipmentData)) {
@@ -148,6 +163,10 @@ function processAllData() {
     if (typeof window.cardData !== 'undefined' && Array.isArray(window.cardData)) {
         window.cardData = processCardsData(window.cardData);
         console.log("Card data processed.");
+    }
+    if (typeof window.artifactData !== 'undefined' && Array.isArray(window.artifactData)) {
+        window.artifactData = processArtifactData(window.artifactData);
+        console.log("Artifact data processed.");
     }
     console.log("--- Data processing finished ---");
 }


### PR DESCRIPTION
This commit introduces the 'Artifact Sets' feature to the Damage Simulator, allowing users to select an artifact set and adjust the levels of its pieces to see the impact on their stats.

Key changes include:
- **UI Implementation:** Added a new column in `damage_simulator.html` for artifact selection, including a dropdown for sets and level controls for each artifact piece (Rune, Relic, Scroll, Gem).
- **Data Processing:** Updated `database-converter.js` to process `Artifacts.js`, parsing per-refine and full-set bonuses into a machine-readable format.
- **Calculation Integration:** Modified `main.js` to:
  - Manage artifact state (`equippedArtifacts`).
  - Integrate artifact stats into the `calculateGearBonuses` function, correctly applying bonuses based on piece levels and the full set bonus.
  - Include artifact state in the build saving/loading system.
- **Verification:** Added a Playwright script to verify the frontend functionality of the new feature.