### PR TITLE
feat: Add tooltip to equipment selection modal

### DIFF
--- a/equipment-modal.js
+++ b/equipment-modal.js
@@ -97,6 +97,28 @@ document.addEventListener('DOMContentLoaded', () => {
         closeModal();
     });
 
+    equipmentGrid.addEventListener('mouseover', (e) => {
+        const card = e.target.closest('.equipment-card');
+        if (!card || !card.dataset.equipmentId) return;
+
+        const equipmentId = card.dataset.equipmentId;
+        const item = window.equipmentData.find(item => item.EquipmentId === equipmentId);
+
+        if (item && typeof generateItemCardHTML === 'function') {
+            const tooltip = document.getElementById('tooltip');
+            tooltip.innerHTML = generateItemCardHTML(item);
+            tooltip.style.display = 'block';
+        }
+    });
+
+    equipmentGrid.addEventListener('mouseout', (e) => {
+        const card = e.target.closest('.equipment-card');
+        if (!card) return;
+        const tooltip = document.getElementById('tooltip');
+        tooltip.style.display = 'none';
+        tooltip.innerHTML = '';
+    });
+
     modalCloseBtn.addEventListener('click', closeModal);
     modalOverlay.addEventListener('click', (event) => {
         if (event.target === modalOverlay) {


### PR DESCRIPTION
This commit adds a tooltip to the equipment selection modal in the Damage Simulator. When a user hovers over an item in the selection grid, a tooltip now appears, displaying the item's detailed information.

- Added `mouseover` and `mouseout` event listeners to the equipment grid in `equipment-modal.js`.
- Used event delegation to handle events for the dynamically generated equipment cards.
- On `mouseover`, the corresponding equipment data is fetched, and the existing `generateItemCardHTML` function from `main.js` is used to populate and display the tooltip.
- On `mouseout`, the tooltip is hidden.

This functionality mirrors the existing tooltip behavior in the card selection modal, enhancing user experience by providing an item preview before selection.