### PR TITLE
Fix: Ensure equipped gear UI persists on refresh

### DIFF
--- a/main.js
+++ b/main.js
@@ -489,7 +489,7 @@ function updateGearSlotUI(slotId) {
         selectStatsBtn.classList.add('hidden');
 
     } else {
-        const item = window.equipmentData.find(e => e.EquipmentId === gearInfo.itemId);
+        const item = window.equipmentData.find(e => e.EquipmentId == gearInfo.itemId);
         if (item) {
             selectStatsBtn.classList.remove('hidden');
             let namePrefix = '';
@@ -588,8 +588,9 @@ function updateGearSlotUI(slotId) {
 
 
 function updateAllGearSlotsUI() {
-    Object.keys(gearSlotLayout.left).concat(Object.keys(gearSlotLayout.right)).forEach(slotId => {
-        updateGearSlotUI(slotId);
+    const allSlots = [...gearSlotLayout.left, ...gearSlotLayout.right];
+    allSlots.forEach(slot => {
+        updateGearSlotUI(slot.id);
     });
 }
 


### PR DESCRIPTION
The `updateAllGearSlotsUI` function was incorrectly using `Object.keys()` on an array of gear slot objects. This resulted in iterating over array indices ('0', '1', '2'...) instead of the actual slot IDs ('head', 'weapon'...).

This caused the UI update to fail on page load when restoring the build from cookies, as it couldn't find the slot wrappers by the numeric indices.

The fix is to iterate over the array of slot objects directly and use the `slot.id` property to update the UI. This ensures that the correct slot elements are targeted and updated when the page is reloaded.

Additionally, the item lookup in `updateGearSlotUI` is changed to use loose equality (`==`) to handle potential data type mismatches between the `itemId` stored in the cookie and the `EquipmentId` in the data files.