### PR TITLE
Fix: Ensure ranged weapons receive correct stat rolls

### DIFF
--- a/main.js
+++ b/main.js
@@ -97,6 +97,7 @@ const statRollData = {
         },
         selection: ['line1', 'line23', 'line23']
     },
+    "Ranged": { "type": "Ranged Weapon" },
     "Axe": { "type": "Melee Weapon" },
     "Dagger": { "type": "Melee Weapon" },
     "Mace": { "type": "Melee Weapon" },
@@ -454,7 +455,7 @@ function resetToDefaults() {
 
 function getStatDetailsForItem(item) {
     if (!item) return {};
-    let itemConfigKey = item.Type;
+    let itemConfigKey = item['Stat Type'] || item.Type;
     let itemConfig = statRollData[itemConfigKey];
     if (itemConfig && itemConfig.type) {
         itemConfigKey = itemConfig.type;
@@ -1047,7 +1048,7 @@ function openStatSelectionModal(slotId, isArtifact = false) {
         document.getElementById('stat-selection-modal-title').textContent = `Select Stats for ${item.Name}`;
 
 
-        let itemConfigKey = item.Type;
+        let itemConfigKey = item['Stat Type'] || item.Type;
         itemConfig = statRollData[itemConfigKey];
         if (itemConfig && itemConfig.type) {
             itemConfigKey = itemConfig.type;


### PR DESCRIPTION
The Stormpiercer weapon, despite being a spear, has a "Ranged" stat type. The previous logic did not correctly handle this override, causing it to receive melee stat rolls.

This change updates the stat selection logic to prioritize the 'Stat Type' property from the equipment data over the general 'Type'. An alias for "Ranged" to "Ranged Weapon" has also been added to the statRollData object to ensure correct mapping.

This makes the system more robust and ensures that weapons with specific stat type overrides are handled correctly.