### PR TITLE
Fix: Ensure correct stat rolls for all weapon types

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,6 +98,7 @@ const statRollData = {
         selection: ['line1', 'line23', 'line23']
     },
     "Ranged": { "type": "Ranged Weapon" },
+    "Melee": { "type": "Melee Weapon" },
     "Axe": { "type": "Melee Weapon" },
     "Dagger": { "type": "Melee Weapon" },
     "Mace": { "type": "Melee Weapon" },


### PR DESCRIPTION
This commit resolves two issues:
1. Ranged weapons like "Stormpiercer" were incorrectly receiving melee stat rolls because the stat lookup logic did not account for the item's `Stat Type` override.
2. A previous fix attempt caused a regression where melee weapons no longer received any stat rolls.

The solution involves:
- Updating the stat selection logic in `getStatDetailsForItem` and `openStatSelectionModal` to prioritize the `item['Stat Type']` property over the general `item.Type`.
- Adding aliases to the `statRollData` object to map both "Ranged" and "Melee" stat types to their respective "Ranged Weapon" and "Melee Weapon" configurations.

This approach makes the stat roll system more robust and ensures all weapons are assigned their correct stat options.