### PR TITLE
feat: Display item cards in set tooltip

### DIFF
--- a/database.html
+++ b/database.html
@@ -1152,9 +1152,38 @@
                     } else if (target.classList.contains('set-tooltip')) {
                         const setName = target.getAttribute('data-set-name');
                         const setBonus = decodeURIComponent(target.getAttribute('data-set-bonus'));
+
+                        // Find all items in the set
+                        const setItems = equipmentData.filter(item => item.Set === setName);
+
+                        let itemsHtml = '';
+                        if (setItems.length > 0) {
+                            itemsHtml = setItems.map(item => {
+                                // We need to add itemType for the generator function to work
+                                const itemWithtype = {...item, itemType: 'Equipment'};
+                                // Generate the card but remove the source info to avoid clutter
+                                return generateItemCardHTML(itemWithtype).replace(renderSources(itemWithtype, 'indigo'), '');
+                            }).join('');
+                        }
+
+                        let bonusHtml = '';
                         if (setBonus) {
-                            content = `<h4 class="font-bold text-white text-base mb-2">${setName} Set Bonus</h4>`;
-                            content += `<div class="font-mono text-sm">${parseStats(setBonus)}</div>`;
+                            bonusHtml = `
+                                <div class="bg-gray-800/70 rounded-lg border border-gray-700/50 p-4">
+                                    <h4 class="font-bold text-lg text-white mb-2">${setName} Set Bonus</h4>
+                                    <div class="font-mono text-sm">${parseStats(setBonus)}</div>
+                                </div>
+                            `;
+                        }
+
+                        if (itemsHtml || bonusHtml) {
+                            content = `
+                                <div class="flex flex-col gap-2">
+                                    ${itemsHtml}
+                                    ${bonusHtml}
+                                </div>
+                            `;
+                            tooltip.style.padding = '0'; // The cards have their own padding
                             displayTooltip = true;
                         }
                     } else if (target.classList.contains('boss-icon')) {


### PR DESCRIPTION
Previously, hovering over an equipment set name in the database only showed the set bonus stats.

This change enhances the tooltip to display the full item cards for all equipment pieces that belong to the hovered set, in addition to the set bonus stats.

This provides a more comprehensive and user-friendly way to view equipment sets without needing to search for each piece individually.

The implementation reuses the existing `generateItemCardHTML` function to maintain a consistent UI.