### PR TITLE
feat: Enhance equipment set tooltip with item previews and stats

### DIFF
--- a/database.html
+++ b/database.html
@@ -398,7 +398,8 @@
                             statsHtml += `${parseStats(item.PrimaryStats)}`;
                         }
                         if (item.PrimaryStats && item.SecondaryStats) {
-                            statsHtml += '<br>'; // Add a line break if both exist
+                            // Visual separator
+                            statsHtml += '<div class="w-full h-px bg-gray-600/50 my-1"></div>';
                         }
                         if (item.SecondaryStats) {
                             statsHtml += `${parseStats(item.SecondaryStats)}`;


### PR DESCRIPTION
This change enhances the equipment set tooltip in the database based on user feedback.

The tooltip now displays:
- The set bonus information at the top.
- Smaller, preview-sized item cards for each piece in the set.
- The item preview cards are arranged in a two-column grid to save space and improve readability.
- Each preview card now includes the item's primary and secondary stats in a compact format, with a visual separator between them.

A new `generateItemPreviewCardHTML` function was created to handle the smaller card generation, and the tooltip logic was updated to use this new function and layout.