### PR TITLE
feat: Search card stats in modal

### DIFF
--- a/card-modal.js
+++ b/card-modal.js
@@ -49,7 +49,10 @@ function populateCardGrid(itemType, searchTerm = '') {
 
     const compatibleCards = window.cardData.filter(card => {
         const matchesType = card.Slot === cardSlotType;
-        const matchesSearch = searchTerm ? card.Name.toLowerCase().includes(searchTerm.toLowerCase()) : true;
+        const lowerCaseSearchTerm = searchTerm ? searchTerm.toLowerCase() : '';
+        const matchesSearch = searchTerm
+            ? (card.Name.toLowerCase().includes(lowerCaseSearchTerm) || (card.Stats && card.Stats.toLowerCase().includes(lowerCaseSearchTerm)))
+            : true;
         return matchesType && matchesSearch;
     });
 


### PR DESCRIPTION
This commit enhances the search functionality in the 'Select a Card' modal. The filtering logic in `populateCardGrid` in `card-modal.js` has been updated to search for the user's input term within the card's name (`card.Name`) and its raw stat string (`card.Stats`).

This provides a better user experience by allowing users to find cards based on their effects, not just their names.