### PR TITLE
feat: Implement Share Build feature

### DIFF
--- a/damage_simulator.html
+++ b/damage_simulator.html
@@ -287,6 +287,7 @@
                             <button id="reset-build-btn" class="text-xs bg-red-600 hover:bg-red-700 text-white font-semibold py-1 px-3 rounded-md transition-colors">Reset Page</button>
                             <button id="copy-build-btn" class="text-xs bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-1 px-3 rounded-md transition-colors">Copy to New</button>
                         </div>
+                        <button id="share-build-btn" class="text-xs bg-green-600 hover:bg-green-700 text-white font-semibold py-1 px-3 rounded-md transition-colors">Share Build</button>
                     </div>
                     <h2 class="card-header">Character Stats</h2>
                     <div class="space-y-3">
@@ -459,6 +460,7 @@
         </div>
     </div>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js"></script>
     <script src="sidebar.js" defer></script>
     <script src="classes.js" defer></script>
     <script src="monsters.js" defer></script>


### PR DESCRIPTION
This commit introduces a "Share Build" feature to the Damage & Stat Simulator, allowing users to generate a shareable link that contains their current build configuration.

- Adds a "Share Build" button to the user interface.
- Integrates the `lz-string` library to compress the build's JSON data, creating a compact, URL-friendly string.
- Implements logic to generate a URL with the compressed build data stored in a `?build=` query parameter.
- On page load, the application now checks for the `build` parameter. If it exists, the data is decompressed and used to restore the shared build, taking precedence over locally saved cookie data.
- Refactors the build loading mechanism into a reusable `loadBuildFromData` function to handle data from both URL parameters and cookies.
- Adds a Playwright verification script to test the end-to-end functionality of creating, sharing, and restoring a build.