### PR TITLE
fix(maps): Make mapData globally available

### DIFF
--- a/Maps.js
+++ b/Maps.js
@@ -1,4 +1,4 @@
-const mapData = [
+window.mapData = [
     {
         "Id": "Castle Crypt",
         "Name": "Abyss Castle Crypt",


### PR DESCRIPTION
The Maps Database page was blank because the `mapData` array in `Maps.js` was declared with `const`, making it inaccessible to the rendering script in `database.html`.

This change modifies `Maps.js` to assign the data to `window.mapData`, ensuring it has global scope and can be correctly accessed by the application, which is consistent with how other data files in the project are structured.